### PR TITLE
[codex] Refactor internals and align documentation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,14 +8,15 @@ message: 'To cite package "cffr" in publications use:'
 type: software
 license: GPL-3.0-or-later
 title: 'cffr: Generate Citation File Format (''CFF'') Metadata for R Packages'
-version: 1.4.0
+version: 1.4.0.9000
 doi: 10.21105/joss.03900
 identifiers:
 - type: doi
   value: 10.32614/CRAN.package.cffr
 abstract: Citation File Format ('CFF') version 1.2.0 <https://doi.org/10.5281/zenodo.5171937>
   is a human- and machine-readable file format for software citation metadata. The
-  package provides core utilities to generate and validate this metadata for R packages.
+  package provides core utilities to generate, read, write and validate this metadata
+  for R packages.
 authors:
 - family-names: Hernangómez
   given-names: Diego

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Authors@R: c(
 Description: Citation File Format ('CFF') version 1.2.0
     <doi:10.5281/zenodo.5171937> is a human- and machine-readable file
     format for software citation metadata. The package provides core
-    utilities to generate and validate this metadata for R packages.
+    utilities to generate, read, write and validate this metadata for R
+    packages.
 License: GPL (>= 3)
 URL: https://docs.ropensci.org/cffr/, https://github.com/ropensci/cffr
 BugReports: https://github.com/ropensci/cffr/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cffr
 Title: Generate Citation File Format ('CFF') Metadata for R Packages
-Version: 1.4.0
+Version: 1.4.0.9000
 Authors@R: c(
     person("Diego", "Hernangómez", , "diego.hernangomezherrero@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8457-4658")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,18 @@
 # cffr (development version)
 
+- Internal code and documentation were reviewed and refactored with AI
+  assistance to improve maintainability, consistency and user-facing messages.
+
 # cffr 1.4.0
 
-- DOIs in `inst/CITATION` `url` fields are detected, including those matching the pattern `.*dx.doi.org/`.
-- The `website` field in `definitions.person` and `definitions.entity` uses ROR as a fallback.
+- DOIs in `inst/CITATION` `url` fields are detected, including those matching
+  the pattern `.*dx.doi.org/`.
+- The `website` field in `definitions.person` and `definitions.entity` uses ROR
+  as a fallback.
 - `cff_read()` correctly handles a single `languages` value (#105).
-- `cff_validate()` now uses the [ajv](https://github.com/ajv-validator/ajv) validation engine via `jsonvalidate::json_validate()`, which returns more informative error messages.
+- `cff_validate()` now uses the [ajv](https://github.com/ajv-validator/ajv)
+  validation engine via `jsonvalidate::json_validate()`, which returns more
+  informative error messages.
 
 # cffr 1.3.0
 
@@ -16,13 +23,16 @@
 
 - `as_cff_person()` improves comment detection and parsing across its function
   family.
-- `cff_gha_update()` now runs in `ubuntu-latest` by default to save [GitHub Actions quota](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers) (#90, thanks to \@Pakillo).
+- `cff_gha_update()` now runs in `ubuntu-latest` by default to save [GitHub
+  Actions
+  quota](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers)
+  (#90, thanks to \@Pakillo).
 - The mapping of **CRAN** packages to SPDX codes was updated.
 
 # cffr 1.2.0
 
-- `cff_write()` gains a new `r_citation` argument. When it is set to `TRUE`,
-  an **R** citation file (`inst/CITATION`) is generated or updated with the
+- `cff_write()` gains a new `r_citation` argument. When it is set to `TRUE`, an
+  **R** citation file (`inst/CITATION`) is generated or updated with the
   information from the generated `CITATION.cff` file. **No backup copy is
   created**. For more control, use `cff_write_citation()` (#79).
 - `repository-code` now also recognizes [Codeberg](https://codeberg.org/) as a
@@ -50,8 +60,8 @@
 
 # cffr 1.0.1
 
-- `cff_write()` gains a new `encoding` argument to make it work with
-  different encodings. See `iconv()`.
+- `cff_write()` gains a new `encoding` argument to make it work with different
+  encodings. See `iconv()`.
 - Fixed **NOTEs** caused by empty lines in docs.
 
 # cffr 1.0.0
@@ -107,8 +117,8 @@ The API has been completely revised to provide more clarity on function naming
 and to facilitate internal maintenance. This change **only** **affects non-core
 functions**. Each function now does fewer things but does them better. The old
 API [has been
-deprecated](https://lifecycle.r-lib.org/articles/stages.html#deprecated) and
-now warns when used, providing advice on the replacement function.
+deprecated](https://lifecycle.r-lib.org/articles/stages.html#deprecated) and now
+warns when used, providing advice on the replacement function.
 
 #### Deprecation
 
@@ -139,8 +149,8 @@ now warns when used, providing advice on the replacement function.
 
 - The minimum required **R** version is now **4.0.0**.
 - The BibTeX crosswalk was updated (see
-  `vignette("bibtex-cff", package = "cffr")`), with corresponding changes in
-  the mapping performed by `as_bibtex()` and `cff_parse_citation()`:
+  `vignette("bibtex-cff", package = "cffr")`), with corresponding changes in the
+  mapping performed by `as_bibtex()` and `cff_parse_citation()`:
   - **\@inbook** and **\@book** gain a new value in CFF when **series** is
     provided: `collection-type: book-series`.
   - **cffr** can now handle BibLaTeX **\@inbook**, which differs significantly
@@ -155,8 +165,8 @@ now warns when used, providing advice on the replacement function.
 
 ## New features
 
-- `write_citation()` is a new function that can generate an `inst/CITATION`
-  file from a `cff` object (#51).
+- `write_citation()` is a new function that can generate an `inst/CITATION` file
+  from a `cff` object (#51).
 
 ## Enhancements
 
@@ -191,8 +201,8 @@ now warns when used, providing advice on the replacement function.
 - `preferred-citation` is only produced when a `CITATION` **R** file has been
   provided with the package (#37).
 - Improved email handling for authors.
-- Added `cff_read()`. This functionality was already implemented in `cff()`,
-  but the new function provides clarity.
+- Added `cff_read()`. This functionality was already implemented in `cff()`, but
+  the new function provides clarity.
 
 # cffr 0.2.3
 
@@ -209,16 +219,16 @@ now warns when used, providing advice on the replacement function.
 
 # cffr 0.2.0
 
-- **cffr** now also extracts information about package dependencies and adds
-  the main citation of the dependencies to the `references` field, using
+- **cffr** now also extracts information about package dependencies and adds the
+  main citation of the dependencies to the `references` field, using
   `citation(auto = TRUE)`.
   - Added the `dependencies` argument to `cff_create()` and `cff_write()`.
 - Other improvements to `cff_parse_citation()` include:
-  - `cff_parse_citation()` extracts more information about authors, based on
-    the fields provided in the `DESCRIPTION` file.
+  - `cff_parse_citation()` extracts more information about authors, based on the
+    fields provided in the `DESCRIPTION` file.
   - `cff_parse_citation()` does a better job extracting information from
-    `bibentry()`/BibTeX and mapping it to `preferred-citation/references`
-    fields of CFF.
+    `bibentry()`/BibTeX and mapping it to `preferred-citation/references` fields
+    of CFF.
 - Added new functions for working with git pre-commit hooks
   [![Experimental](https://lifecycle.r-lib.org/articles/figures/lifecycle-experimental.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental):
   - `cff_git_hook_install()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# cffr (development version)
+
 # cffr 1.4.0
 
 - DOIs in `inst/CITATION` `url` fields are detected, including those matching the pattern `.*dx.doi.org/`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Internal code and documentation were reviewed and refactored with AI
   assistance to improve maintainability, consistency and user-facing messages.
+- Tests were improved with AI assistance to reduce dependence on external
+  services and make internal fixtures more robust.
 
 # cffr 1.4.0
 

--- a/R/as_bibentry.R
+++ b/R/as_bibentry.R
@@ -1,10 +1,6 @@
 #' Create [`bibentry`] objects from several sources
 #'
-#' @rdname as_bibentry
-#' @name as_bibentry
-#' @order 1
 #' @description
-#'
 #' This function creates [`bibentry`] objects from different metadata sources
 #' ([`cff`] objects, `DESCRIPTION` files and other sources). The inverse
 #' transformation (`bibentry` object to [`cff_ref_lst`]) can be done with the
@@ -13,18 +9,37 @@
 #' With [`toBibtex()`][toBibtex.cff()] it is possible to convert [`cff`]
 #' objects to BibTeX markup on the fly. See **Examples**.
 #'
-#' @seealso
-#' [utils::bibentry()] to understand more about the `bibentry` class.
+#' @param x The source used to generate the `bibentry` object via
+#'   \CRANpkg{cffr}. It can be:
+#'   - A missing value, which retrieves the `DESCRIPTION` file from your
+#'     in-development package.
+#'   - An existing `cff` object created with [cff()], [cff_create()], or
+#'     [as_cff()].
+#'   - Path to a `CITATION.cff` file (`"CITATION.cff"`).
+#'   - The name of an installed package (`"jsonlite"`).
+#'   - Path to a `DESCRIPTION` file (`"DESCRIPTION"`).
+#' @param ... Additional arguments to be passed to or from methods.
 #'
-#' - `vignette("r-cff", package = "cffr")` provides details on how the
-#'   metadata of a package is mapped to produce a `cff` object.
+#' @param what Fields to extract from a full `cff` object. The value could be:
+#'   - `preferred`: Create a single entry with the main citation information
+#'     of the package (key `preferred-citation`).
+#'   - `references`: Extract all entries of the `references` key.
+#'   - `all`: Extract both the `preferred-citation` and `references` keys.
 #'
-#' - `vignette("bibtex-cff", package = "cffr")` provides detailed information
-#'   about the internal mapping performed between `cff` objects and BibTeX
-#'   markup (both `cff` to BibTeX and BibTeX to `cff`).
+#' See `vignette("r-cff", package = "cffr")`.
 #'
-#' Other related functions:
-#' - [utils::toBibtex()].
+#' @details
+#' An \R `bibentry` object is the representation of a BibTeX entry. These
+#' objects can be converted to BibTeX markup with [toBibtex()], which creates
+#' an object of class `Bibtex` that can be printed and exported as a valid
+#' BibTeX entry.
+#'
+#' `as_bibentry()` tries to map the information of the source `x` into a [`cff`]
+#' object and performs a mapping of the metadata to BibTeX, according to
+#' `vignette("bibtex-cff", package = "cffr")`.
+#'
+#' @return
+#' `as_bibentry()` returns a `bibentry` object with one or more entries.
 #'
 #' @references
 #' - Patashnik, Oren. "BIBTEXTING" February 1988.
@@ -38,45 +53,26 @@
 #'   *The cffr package, Vignettes*. \doi{10.21105/joss.03900},
 #'   <https://docs.ropensci.org/cffr/articles/bibtex-cff.html>.
 #'
-#' @param x The source used to generate the `bibentry` object via
-#'   \CRANpkg{cffr}. It can be:
-#'   - A missing value, which retrieves the `DESCRIPTION` file from your
-#'     in-development package.
-#'   - An existing `cff` object created with [cff()], [cff_create()], or
-#'     [as_cff()].
-#'   - Path to a CITATION.cff file (`"CITATION.cff"`).
-#'   - The name of an installed package (`"jsonlite"`).
-#'   - Path to a DESCRIPTION file (`"DESCRIPTION"`).
-#' @param ... Additional arguments to be passed to or from methods.
+#' @seealso
+#' [utils::bibentry()] to understand more about the `bibentry` class.
 #'
-#' @param what Fields to extract from a full `cff` object. The value could be:
-#'   - `preferred`: Create a single entry with the main citation information
-#'     of the package (key `preferred-citation`).
-#'   - `references`: Extract all entries of the `references` key.
-#'   - `all`: Extract both the `preferred-citation` and `references` keys.
+#' - `vignette("r-cff", package = "cffr")` provides details on how the
+#'   metadata of a package is mapped to produce a `cff` object.
 #'
-#' See `vignette("r-cff", package = "cffr")`.
+#' - `vignette("bibtex-cff", package = "cffr")` provides detailed information
+#'   about the internal mapping performed between `cff` objects and BibTeX
+#'   markup, both `cff` to BibTeX and BibTeX to `cff`.
+#'
+#' Other related functions:
+#' - [utils::toBibtex()].
 #'
 #' @family bibtex
 #' @family s3method
-#'
-#' @details
-#'
-#' An \R `bibentry` object is the representation of a BibTeX entry. These
-#' objects can be converted to BibTeX markup with [toBibtex()], which creates
-#' an object of class `Bibtex` that can be printed and exported as a valid
-#' BibTeX entry.
-#'
-#' `as_bibtex()` tries to map the information of the source `x` into a [`cff`]
-#' object and performs a mapping of the metadata to BibTeX, according to
-#' `vignette("bibtex-cff", package = "cffr")`.
-#'
-#' @return
-#' `as_bibentry()` returns a `bibentry` object with one or more entries.
-#'
 #' @export
 #' @encoding UTF-8
-#'
+#' @rdname as_bibentry
+#' @name as_bibentry
+#' @order 1
 #' @examples
 #' \donttest{
 #' # From a cff object ----
@@ -84,7 +80,7 @@
 #'
 #' cff_object
 #'
-#' # bibentry object.
+#' # A bibentry object.
 #' bib <- as_bibentry(cff_object)
 #'
 #' class(bib)
@@ -160,7 +156,7 @@ as_bibentry.character <- function(
     msg <- paste0('install.packages("', x, '")')
     # nolint end
     cli::cli_abort(paste(
-      "Don't know how to extract a {.cls bibentry} from {.val {x}}.",
+      "Cannot extract a {.cls bibentry} from {.val {x}}.",
       "If it is a package, run {.run {msg}} first."
     ))
   }
@@ -193,9 +189,9 @@ as_bibentry.list <- function(x, ...) {
   # Return an empty object if a key is missing.
   if (inherits(bib, "try-error")) {
     message <- attributes(bib)$condition$message
-    cli::cli_alert_danger(paste("Cannot convert to {.fn bibentry}: "))
+    cli::cli_alert_danger("Cannot convert to {.fn bibentry}.")
     cli::cli_alert_info(message)
-    cli::cli_alert_warning("Returning empty {.cls bibentry}")
+    cli::cli_alert_warning("Returning an empty {.cls bibentry}.")
     return(bibentry())
   }
 
@@ -242,7 +238,7 @@ as_bibentry.cff <- function(
   if (is.null(obj_extract)) {
     cli::cli_alert_warning(paste0(
       "In {.arg x}, did not find anything with {.arg what} = {.val {what}}. ",
-      "Returning empty {.cls bibentry}."
+      "Returning an empty {.cls bibentry}."
     ))
     return(bibentry())
   }

--- a/R/as_cff.R
+++ b/R/as_cff.R
@@ -1,9 +1,9 @@
 #' Coerce lists, `person` and `bibentry` objects to [`cff`]
 #'
 #' @description
-#' `as_cff()` turns an existing list-like \R object into a so-called
-#' [`cff`], a list with class `cff`, with the corresponding
-#' [sub-class][cff_class] if applicable.
+#' `as_cff()` turns an existing list-like \R object into a [`cff`] object,
+#' a list with class `cff` and the corresponding [subclass][cff_class] when
+#' applicable.
 #'
 #' `as_cff` is an S3 generic, with methods for:
 #' - `person` objects as produced by [utils::person()].
@@ -15,10 +15,7 @@
 #'   list.
 #' @param ... Additional arguments to be passed on to other methods.
 #'
-#' @rdname as_cff
-#'
 #' @return
-#'
 #' - `as_cff.person()` returns an object with classes
 #'   [`cff_pers_lst, cff`][cff_pers_lst].
 #' - `as_cff.bibentry()` and `as_cff.Bibtex()` return an object with classes
@@ -29,8 +26,6 @@
 #'   corresponding subclass.
 #'
 #' Learn more about the \CRANpkg{cffr} class system in [cff_class].
-#'
-#' @family s3method
 #'
 #' @details
 #' For `as_cff.bibentry()` and `as_cff.Bibtex()`, see
@@ -46,15 +41,15 @@
 #' - [cff_modify()]: Modify a `cff` object.
 #' - [cff_create()]: Create a `cff` object for an \R package.
 #' - [cff_read()]: Create a `cff` object from an external file.
-#' - [as_cff_person()]: Recommended way to create persons in CFF format.
+#' - [as_cff_person()]: Recommended way to create CFF person metadata.
 #'
 #' Learn more about the \CRANpkg{cffr} class system in [cff_class].
 #'
+#' @family s3method
 #' @export
 #' @encoding UTF-8
-#'
+#' @rdname as_cff
 #' @examples
-#'
 #' # Convert a list to a `cff` object.
 #' cffobj <- as_cff(list(
 #'   "cff-version" = "1.2.0",
@@ -84,16 +79,16 @@ as_cff <- function(x, ...) {
   UseMethod("as_cff")
 }
 
-#' @rdname as_cff
 #' @export
 #' @encoding UTF-8
+#' @rdname as_cff
 as_cff.default <- function(x, ...) {
   as_cff(as.list(x), ...)
 }
 
-#' @rdname as_cff
 #' @export
 #' @encoding UTF-8
+#' @rdname as_cff
 as_cff.list <- function(x, ...) {
   # Clean up empty top-level values.
   clean_up <- vapply(x, is.null, FUN.VALUE = logical(1))
@@ -101,16 +96,16 @@ as_cff.list <- function(x, ...) {
   new_cff(x_clean)
 }
 
-#' @rdname as_cff
 #' @export
 #' @encoding UTF-8
+#' @rdname as_cff
 as_cff.person <- function(x, ...) {
   as_cff_person(x)
 }
 
-#' @rdname as_cff
 #' @export
 #' @encoding UTF-8
+#' @rdname as_cff
 as_cff.bibentry <- function(x, ...) {
   cff_ref <- as_cff_reference(x)
   clean_up <- vapply(cff_ref, is.null, FUN.VALUE = logical(1))
@@ -130,9 +125,9 @@ as_cff.bibentry <- function(x, ...) {
   cff_refs_class
 }
 
-#' @rdname as_cff
 #' @export
 #' @encoding UTF-8
+#' @rdname as_cff
 as_cff.Bibtex <- function(x, ...) {
   tmp <- tempfile(fileext = ".bib")
   writeLines(x, tmp)

--- a/R/as_cff_person.R
+++ b/R/as_cff_person.R
@@ -23,19 +23,6 @@
 #' The inverse transformation (`cff_pers_lst` to `person`) can be done with the
 #' methods [as.person.cff_pers()] and [as.person.cff_pers_lst()].
 #'
-#' @seealso
-#' Examples in `vignette("cffr", package = "cffr")` and [utils::person()].
-#'
-#' Learn more about the `cff_pers_lst` and `cff_pers` classes in [cff_class].
-#'
-#' @export
-#' @encoding UTF-8
-#' @rdname as_cff_person
-#' @name as_cff_person
-#' @order 1
-#'
-#' @family s3method
-#'
 #' @param x Any \R object.
 #' @param ... Ignored by this method.
 #'
@@ -54,7 +41,6 @@
 #' [`cff_pers, cff`][cff_pers].
 #'
 #' @details
-#'
 #' `as_cff_person()` recognizes whether the input should be converted using the
 #' CFF reference for `definitions.person` or `definitions.entity`.
 #'
@@ -98,6 +84,16 @@
 #'
 #' See **Examples** for more information.
 #'
+#' @seealso
+#' Examples in `vignette("cffr", package = "cffr")` and [utils::person()].
+#' Learn more about the `cff_pers_lst` and `cff_pers` classes in [cff_class].
+#'
+#' @family s3method
+#' @export
+#' @encoding UTF-8
+#' @rdname as_cff_person
+#' @name as_cff_person
+#' @order 1
 #' @examples
 #' # Create a person object.
 #' a_person <- person(

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -1,4 +1,4 @@
-#' Check if a string is an email
+#' Check whether a string is an email
 #' @param email A string to be evaluated.
 #' @noRd
 is_email <- function(email) {
@@ -18,7 +18,7 @@ is_email <- function(email) {
   x
 }
 
-#' Check if a string is a URL
+#' Check whether a string is a URL
 #' @param url A URL to be evaluated.
 #' @noRd
 is_url <- function(url) {
@@ -30,7 +30,7 @@ is_url <- function(url) {
   x
 }
 
-#' Check if a string contains a substring
+#' Check whether a string contains a substring
 #'
 #' @param x A string.
 #' @param sub A substring to be evaluated.
@@ -47,14 +47,14 @@ is_substring <- function(x, sub) {
   }
 }
 
-#' Check if an object is a `cff` object
+#' Check whether an object is a `cff` object
 #' @param x An object to be evaluated.
 #' @noRd
 is_cff <- function(x) {
   inherits(x, "cff")
 }
 
-#' Check if an object is a CFF file
+#' Check whether an object is a `CITATION.cff` file
 #' @param x An object to be evaluated.
 #' @noRd
 is_cff_file <- function(x) {
@@ -63,7 +63,7 @@ is_cff_file <- function(x) {
   val
 }
 
-#' Check if a URL is from GitHub
+#' Check whether a URL is from GitHub
 #' @param x An object to be evaluated.
 #' @noRd
 is_github <- function(x) {
@@ -72,7 +72,7 @@ is_github <- function(x) {
   res
 }
 
-#' Check if an object has names
+#' Check whether an object has names
 #' @param x An object to be evaluated.
 #' @noRd
 is_named <- function(x) {

--- a/R/cff.R
+++ b/R/cff.R
@@ -3,23 +3,17 @@
 #' A class and utility methods for reading, creating and holding CFF
 #' information. See [cff_class] to learn more about `cff` objects.
 #'
-#' @rdname cff
-#' @name cff
-#' @return
-#'
-#' A [`cff`] object. Under the hood, a `cff` object is a regular [`list`]
-#' object with a special [`print`][print.cff()] method.
-#'
-#' @family core
-#'
 #' @param path `r lifecycle::badge("deprecated")` `path` is no longer supported,
 #'   use [cff_read_cff_citation()] instead.
 #' @param ... Named arguments to be used for creating a [`cff`] object. If no
 #'   arguments are supplied (the default behavior), a minimal valid `cff`
 #'   object is created.
 #'
-#' @details
+#' @return
+#' A [`cff`] object. Under the hood, a `cff` object is a regular [`list`]
+#' object with a special [`print`][print.cff()] method.
 #'
+#' @details
 #' `cff()` converts `_` in the argument name to `-`. For example,
 #' `cff_version = "1.2.0"` is converted to `cff-version = "1.2.0"`.
 #'
@@ -31,8 +25,12 @@
 #' cat(p)
 #'
 #' ```
+#'
+#' @family core
 #' @export
 #' @encoding UTF-8
+#' @rdname cff
+#' @name cff
 #' @examples
 #' # Blank `cff` object.
 #' cff()

--- a/R/cff_create.R
+++ b/R/cff_create.R
@@ -1,19 +1,11 @@
 #' Create a [`cff`] object from several sources
 #'
 #' @description
-#'
 #' Create a full and possibly valid [`cff`] object from a given source. This
-#' object can be written to a `*.cff` file with [cff_write()],
-#' see **Examples**.
+#' object can be written to a `CITATION.cff` file with [cff_write()]. See
+#' **Examples**.
 #'
 #' Most of the heavy lifting of \CRANpkg{cffr} is done by this function.
-#'
-#' @return A [`cff`] object.
-#'
-#' @family core
-#'
-#' @export
-#' @encoding UTF-8
 #'
 #' @param x The source used to generate
 #'   the [`cff`] object. It can be:
@@ -29,11 +21,23 @@
 #' @param cff_version The Citation File Format schema version that the
 #'   `CITATION.cff` file adheres to for providing the citation metadata.
 #' @param gh_keywords Logical `TRUE/FALSE`. If the package is hosted on
-#'   GitHub, would you like to add the repository topics as keywords?
+#'   GitHub, should the repository topics be added as keywords?
 #' @param dependencies Logical `TRUE/FALSE`. Should the dependencies of your
 #'   package be added to the `references` CFF key?
 #' @param authors_roles Roles to be considered as authors of the package when
 #'   generating the `CITATION.cff` file. See **Details**.
+#'
+#' @return A [`cff`] object.
+#'
+#' @details
+#' If `x` is a path to a `DESCRIPTION` file, or if `inst/CITATION` is not
+#' present in your package, \CRANpkg{cffr} auto-generates a
+#' `preferred-citation` key using the information provided in that file.
+#'
+#' By default, only persons whose role in the `DESCRIPTION` file of the package
+#' is author (`"aut"`) or maintainer (`"cre"`) are considered package authors.
+#' The default setting can be controlled via the `authors_roles` argument. See
+#' **Details** on [person()] for additional information about person roles.
 #'
 #' @seealso
 #' ```{r, echo=FALSE, results='asis'}
@@ -45,30 +49,21 @@
 #' ```
 #'
 #' - [cff_modify()] as the recommended way to modify a `cff` object.
-#' - [cff_write()] for creating a CFF file.
-#' - `vignette("cffr", package = "cffr")` shows an introduction on how
-#'   manipulate [`cff`] objects.
+#' - [cff_write()] for creating a `CITATION.cff` file.
+#' - `vignette("cffr", package = "cffr")` shows an introduction to
+#'   manipulating [`cff`] objects.
 #' - `vignette("r-cff", package = "cffr")` provides details on how the
-#'  metadata of a package is mapped to produce a `cff` object.
+#'   metadata of a package is mapped to produce a `cff` object.
 #'
-#' @details
-#'
-#' If `x` is a path to a `DESCRIPTION` file or if `inst/CITATION` is not present
-#' on your package, \CRANpkg{cffr} would auto-generate a `preferred-citation`
-#' key using the information provided on that file.
-#'
-#' By default, only persons whose role in the `DESCRIPTION` file of the package
-#' is author (`"aut"`) or maintainer (`"cre"`) are considered to be authors
-#' of the package. The default setting can be controlled via the `authors_roles`
-#' argument. See **Details** on [person()] to get additional insights
-#' on person roles.
-#'
+#' @family core
+#' @export
+#' @encoding UTF-8
 #' @examples
 #' \donttest{
-#' # Installed package
+#' # Installed package.
 #' cff_create("jsonlite")
 #'
-#' # Demo file
+#' # Demo file.
 #' demo_file <- system.file("examples/DESCRIPTION_basic", package = "cffr")
 #' cff_create(demo_file)
 #'
@@ -109,30 +104,11 @@ cff_create <- function(
   # Guess source.
   # Use the working directory when `x` is missing.
   if (missing(x)) {
-    hint_source <- "indev"
     x <- getwd()
-  } else if (identical(getwd(), x)) {
-    # This case comes from `cff_write()`.
-    hint_source <- "indev"
-  } else {
-    hint_source <- detect_x_source(x)
   }
+  hint_source <- cff_source_hint(x)
 
-  # Abort for invalid sources.
-  valid_sources <- c("indev", "cff_obj", "package", "description")
-  if (!hint_source %in% valid_sources) {
-    # Prepare the abort message.
-    msg_hint <- switch(hint_source,
-      "dontknow" = paste0(
-        "If it is a package ",
-        "you may need to install it with ",
-        "{.fn install.packages}."
-      ),
-      "bib" = "Maybe try with {.fn cff_read}."
-    )
-
-    cli::cli_abort(paste0("{.arg x} not valid. ", msg_hint))
-  }
+  abort_invalid_cff_source(hint_source)
 
   # Build the CFF object and return paths if any.
   result_paths <- build_cff_and_paths(
@@ -179,8 +155,6 @@ build_cff_and_paths <- function(
 ) {
   collect_list <- list(desc_path = NULL, cffobjend = NULL)
 
-  # "indev", "cff_obj", "package", "description"
-
   # Return `x` when it is already a `cff` object.
   if (is_cff(x)) {
     # Ensure it uses the requested CFF version.
@@ -192,11 +166,7 @@ build_cff_and_paths <- function(
   }
 
   # Get information from DESCRIPTION.
-  desc_path <- switch(hint_source,
-    "indev" = file.path(getwd(), "DESCRIPTION"),
-    "description" = x,
-    "package" = system.file("DESCRIPTION", package = x)
-  )
+  desc_path <- cff_description_path(x, hint_source)
 
   if (is.null(file_path_or_null(desc_path))) {
     cli::cli_abort("No {.file DESCRIPTION} file found with {.arg x}.")
@@ -209,20 +179,7 @@ build_cff_and_paths <- function(
     authors_roles = authors_roles
   )
 
-  # Just for description case
-  try_get_citation <- function(x) {
-    cit1 <- file.path(dirname(x), "inst/CITATION")
-    cit2 <- file.path(dirname(x), "CITATION")
-
-    c(file_path_or_null(cit1), file_path_or_null(cit2))[1]
-  }
-
-  cit_path <- switch(hint_source,
-    "indev" = file.path(getwd(), "inst/CITATION"),
-    "description" = try_get_citation(x),
-    "package" = system.file("CITATION", package = x)
-  )
-
+  cit_path <- cff_citation_path(x, hint_source)
   cit_path <- file_path_or_null(cit_path[1])
 
   if (!is.null(cit_path)) {
@@ -236,4 +193,54 @@ build_cff_and_paths <- function(
   collect_list$cffobjend <- cffobj
 
   collect_list
+}
+
+cff_source_hint <- function(x) {
+  # The working directory case comes from `cff_write()` and in-development use.
+  if (identical(getwd(), x)) {
+    return("indev")
+  }
+
+  detect_x_source(x)
+}
+
+abort_invalid_cff_source <- function(hint_source) {
+  valid_sources <- c("indev", "cff_obj", "package", "description")
+  if (hint_source %in% valid_sources) {
+    return(invisible(NULL))
+  }
+
+  msg_hint <- switch(hint_source,
+    "dontknow" = paste0(
+      "If it is a package ",
+      "you may need to install it with ",
+      "{.fn install.packages}."
+    ),
+    "bib" = "Maybe try with {.fn cff_read}."
+  )
+
+  cli::cli_abort(paste0("{.arg x} is not valid. ", msg_hint))
+}
+
+cff_description_path <- function(x, hint_source) {
+  switch(hint_source,
+    "indev" = file.path(getwd(), "DESCRIPTION"),
+    "description" = x,
+    "package" = system.file("DESCRIPTION", package = x)
+  )
+}
+
+cff_citation_path <- function(x, hint_source) {
+  switch(hint_source,
+    "indev" = file.path(getwd(), "inst/CITATION"),
+    "description" = cff_citation_from_description(x),
+    "package" = system.file("CITATION", package = x)
+  )
+}
+
+cff_citation_from_description <- function(x) {
+  cit1 <- file.path(dirname(x), "inst/CITATION")
+  cit2 <- file.path(dirname(x), "CITATION")
+
+  c(file_path_or_null(cit1), file_path_or_null(cit2))[1]
 }

--- a/R/cff_gha_update.R
+++ b/R/cff_gha_update.R
@@ -1,9 +1,8 @@
 #' Install a \CRANpkg{cffr} GitHub Action
 #'
 #' @description
-#'
-#' This function installs a [GitHub
-#' Action](https://github.com/features/actions) on your repository. The action
+#' This function installs a [GitHub Action](https://github.com/features/actions)
+#' on your repository. The action
 #' updates your `CITATION.cff` when any of these events occur:
 #' - You publish a new release of the package.
 #' - Your `DESCRIPTION` or `inst/CITATION` file is modified.
@@ -13,11 +12,10 @@
 #' @param overwrite Logical. If the action already exists, should it be
 #'   overwritten?
 #'
-#' @return Invisible, this function is called by its side effects.
+#' @return Invisible. This function is called for its side effects.
 #'
 #' @details
-#'
-#' Triggers on your action can be modified, see
+#' Triggers on your action can be modified. See
 #' ```{r, echo=FALSE, results='asis'}
 #'
 #' cat(paste0(" [Events that trigger workflows]",
@@ -26,14 +24,13 @@
 #'
 #' ```
 #'
+#' @family git
+#' @export
+#' @encoding UTF-8
 #' @examples
 #' \dontrun{
 #' cff_gha_update()
 #' }
-#' @export
-#' @encoding UTF-8
-#'
-#' @family git
 cff_gha_update <- function(path = ".", overwrite = FALSE) {
   destdir <- file.path(path, ".github", "workflows")
   checkdir <- dir.exists(destdir)

--- a/R/cff_git_hook.R
+++ b/R/cff_git_hook.R
@@ -1,7 +1,6 @@
 #' Use a git pre-commit hook `r lifecycle::badge("experimental")`
 #'
 #' @description
-#'
 #' Install a
 #'
 #' ```{r, echo=FALSE, results='asis'}
@@ -14,25 +13,9 @@
 #' that reminds you to update your `CITATION.cff` file. This is a wrapper around
 #' [usethis::use_git_hook()].
 #'
-#' @name cff_git_hook
-#'
-#' @family git
-#'
-#' @export
-#' @encoding UTF-8
-#'
 #' @return Invisible. This function is called for its side effects.
 #'
-#' @seealso
-#'
-#' - [usethis::use_git_hook()], which is the underlying function used by
-#'   `cff_git_hook_install()`.
-#'
-#' - [usethis::use_git()] and related function of \CRANpkg{usethis} for using
-#'   Git with \R packages.
-#'
 #' @details
-#'
 #' This function installs a pre-commit hook using
 #' [usethis::use_git_hook()].
 #'
@@ -53,7 +36,7 @@
 #'
 #' This typically occurs when you have updated your `DESCRIPTION` or
 #' `inst/CITATION` files, but those changes do not affect your
-#' `CITATION.cff` file (for example, you are adding new dependencies).
+#' `CITATION.cff` file, for example, when you add new dependencies.
 #'
 #' In those cases, you can override the check by running
 #' `git commit --no-verify` in the terminal.
@@ -68,6 +51,16 @@
 #'
 #' You can remove the pre-commit hook using `cff_git_hook_remove()`.
 #'
+#' @seealso
+#' - [usethis::use_git_hook()], which is the underlying function used by
+#'   `cff_git_hook_install()`.
+#' - [usethis::use_git()] and related functions of \CRANpkg{usethis} for using
+#'   Git with \R packages.
+#'
+#' @family git
+#' @export
+#' @encoding UTF-8
+#' @name cff_git_hook
 #' @examples
 #' \dontrun{
 #' cff_git_hook_install()
@@ -98,7 +91,7 @@ cff_git_hook_remove <- function() {
 
   if (file_exist_abort(hookfile)) {
     cli::cli_alert_info(
-      "Removing git pre-commit hook (was on {.path {hookfile}})"
+      "Removing git pre-commit hook from {.path {hookfile}}."
     )
     unlink(hookfile, force = TRUE)
   }

--- a/R/cff_modify.R
+++ b/R/cff_modify.R
@@ -6,23 +6,11 @@
 #' @param ... Named arguments used to modify `x`. See also the `...`
 #'   argument in [cff()].
 #'
-#' @details
-#'
-#' Keys provided in `...` override the corresponding key in `x`.
-#'
 #' @return
-#'
 #' A [`cff`] object.
 #'
-#' @family core
-#' @export
-#' @encoding UTF-8
-#' @seealso
-#' This function is a wrapper of [utils::modifyList()].
-#'
-#' See [cff()] for creating [`cff`] objects from scratch.
-#'
 #' @details
+#' Keys provided in `...` override the corresponding key in `x`.
 #'
 #' You can add additional keys not detected by [cff_create()] using
 #' the `keys` argument. A list of valid keys can be retrieved with
@@ -36,6 +24,13 @@
 #' ```
 #' for additional details.
 #'
+#' @seealso
+#' This function is a wrapper of [utils::modifyList()]. See [cff()] for
+#' creating [`cff`] objects from scratch.
+#'
+#' @family core
+#' @export
+#' @encoding UTF-8
 #' @examples
 #' x <- cff()
 #' x
@@ -62,7 +57,7 @@ cff_modify <- function(x, ...) {
   }
   new_keys <- list(...)
   if (length(new_keys) == 0) {
-    cli::cli_alert_info("Arguments {.arg ...} are empty. Returning {.arg x}.")
+    cli::cli_alert_info("No {.arg ...} arguments supplied. Returning {.arg x}.")
     return(x)
   }
 

--- a/R/cff_read.R
+++ b/R/cff_read.R
@@ -190,7 +190,7 @@ cff_read_description <- function(
 
   if (gh_keywords) {
     ghtopics <- get_gh_topics(field_list)
-    field_list$keywords <- unique(c(field_list$keywords, ghtopics))
+    field_list$keywords <- desc_gh_keywords(field_list$keywords, ghtopics)
   }
 
   new_cff(field_list)

--- a/R/cff_read.R
+++ b/R/cff_read.R
@@ -15,18 +15,6 @@
 #' - [cff_read_bib()], which requires \CRANpkg{bibtex} (>= 0.5.0) and uses
 #'   [bibtex::read.bib()].
 #'
-#' @export
-#' @encoding UTF-8
-#' @rdname cff_read
-#' @family reading
-#' @seealso
-#'
-#' The underlying functions used for reading external files:
-#' - [yaml::read_yaml()] for `CITATION.cff` files.
-#' - [desc::desc()] for `DESCRIPTION` files.
-#' - [utils::readCitationFile()] for \R citation files.
-#' - [bibtex::read.bib()] for BibTeX files (extension `*.bib`).
-#'
 #' @param path Path to a file.
 #' @param encoding Encoding to be assumed for `path`. See [readLines()].
 #' @param meta A list of package metadata as obtained by
@@ -37,11 +25,10 @@
 #' @inheritParams cff_create
 #'
 #' @return
-#'
 #' - `cff_read_cff_citation()` and `cff_read_description()` return an object
 #'   with class `cff`.
 #' - `cff_read_citation()` and `cff_read_bib()` return an object of classes
-#'   [`cff_ref_lst, cff`][cff_ref_lst] according to the `definitions.references`
+#'   [`cff_ref_lst, cff`][cff_ref_lst] according to the `definitions.reference`
 #'   specified in the
 #' ```{r, echo=FALSE, results='asis'}
 #'
@@ -53,8 +40,17 @@
 #'
 #' Learn more about the \CRANpkg{cffr} class system in [cff_class].
 #'
-#' @references
+#' @details
+#' For details of `cff_read_description()`, see [cff_create()].
 #'
+#' ## The `meta` object
+#'
+#' Section 1.9 CITATION files of *Writing R Extensions* (R Core Team 2023)
+#' specifies how to create dynamic `CITATION` files using a `meta` object.
+#' Therefore, the `meta` argument in [cff_read_citation()] may be needed to
+#' read some files correctly.
+#'
+#' @references
 #' - R Core Team (2023). _Writing R Extensions_.
 #'   <https://cran.r-project.org/doc/manuals/r-release/R-exts.html>
 #'
@@ -62,21 +58,19 @@
 #'   *The cffr package, Vignettes*. \doi{10.21105/joss.03900},
 #'   <https://docs.ropensci.org/cffr/articles/bibtex-cff.html>.
 #'
-#' @details
+#' @seealso
+#' The underlying functions used for reading external files:
+#' - [yaml::read_yaml()] for `CITATION.cff` files.
+#' - [desc::desc()] for `DESCRIPTION` files.
+#' - [utils::readCitationFile()] for \R citation files.
+#' - [bibtex::read.bib()] for BibTeX files (extension `*.bib`).
 #'
-#' For details of `cff_read_description()`, see [cff_create()].
-#'
-#' ## The `meta` object
-#'
-#' Section 1.9 CITATION files of *Writing R Extensions* (R Core Team 2023)
-#' specifies how to create dynamic `CITATION` files using `meta` object, hence
-#' the `meta` argument in [cff_read_citation()] may be needed for reading
-#' some files correctly.
-#'
+#' @family reading
+#' @export
+#' @encoding UTF-8
+#' @rdname cff_read
 #' @examples
-#'
-#' # Create a `cff` object from a CFF file.
-#'
+#' # Create a `cff` object from a `CITATION.cff` file.
 #' from_cff_file <- cff_read(system.file("examples/CITATION_basic.cff",
 #'   package = "cffr"
 #' ))
@@ -91,7 +85,6 @@
 #' from_desc
 #'
 #' # Create a `cff` object from BibTeX.
-#'
 #' if (requireNamespace("bibtex", quietly = TRUE)) {
 #'   from_bib <- cff_read(system.file("examples/example.bib",
 #'     package = "cffr"
@@ -118,7 +111,7 @@ cff_read <- function(path, ...) {
 
   if (filetype == "dontknow") {
     cli::cli_abort(paste0(
-      "Don't recognize the file type of {.file {path}}.",
+      "Cannot recognize the file type of {.file {path}}.",
       " Use a specific function, such as {.fn cffr:cff_read_description}."
     ))
   }
@@ -128,7 +121,7 @@ cff_read <- function(path, ...) {
     "description" = cff_read_description(path, ...),
     "bib" = cff_read_bib(path, ...),
     "citation" = cff_read_citation(path, ...),
-    cli::cli_abort("Do not know how to read {.val {x}}.")
+    cli::cli_abort("Cannot read {.val {x}}.")
   )
 
   endobj
@@ -216,8 +209,8 @@ cff_read_citation <- function(path, meta = NULL, ...) {
     # nolint end
 
     cli::cli_alert_warning(paste0(
-      "{.arg meta} should be {.val NULL} or {.obj_type_friendly {ex}},",
-      " not {.obj_type_friendly {meta}}. Using {.arg meta = NULL}."
+      "{.arg meta} should be {.val NULL} or {.obj_type_friendly {ex}}, ",
+      "not {.obj_type_friendly {meta}}. Using {.arg meta = NULL}."
     ))
     meta <- NULL
   }
@@ -228,8 +221,8 @@ cff_read_citation <- function(path, meta = NULL, ...) {
   # If there is an error, try again.
   if (inherits(the_cit, "try-error")) {
     cli::cli_alert_warning(paste0(
-      "It was not possible to read {.file {path}} with the {.arg meta} ",
-      "provided. Trying with {.code packageDescription('base')}."
+      "Could not read {.file {path}} with the provided {.arg meta}. ",
+      "Trying with {.code packageDescription('base')}."
     ))
     new_meta <- packageDescription("base")
     the_cit <- try(
@@ -238,7 +231,9 @@ cff_read_citation <- function(path, meta = NULL, ...) {
     )
     # nocov start
     if (inherits(the_cit, "try-error")) {
-      cli::cli_alert_danger("Cannot read {.file path}. Returning {.val NULL}.")
+      cli::cli_alert_danger(
+        "Cannot read {.file {path}}. Returning {.val NULL}."
+      )
       return(NULL)
     }
     # nocov end
@@ -250,8 +245,8 @@ cff_read_citation <- function(path, meta = NULL, ...) {
 
 #' @export
 #' @encoding UTF-8
-#' @family bibtex
 #' @rdname cff_read
+#' @family bibtex
 cff_read_bib <- function(path, encoding = "UTF-8", ...) {
   file_exist_abort(path, abort = TRUE)
 

--- a/R/cff_read_bib_text.R
+++ b/R/cff_read_bib_text.R
@@ -4,25 +4,13 @@
 #' Convert a `character` string representing a BibTeX entry into a
 #' [`cff_ref_lst`] object.
 #'
-#' @family bibtex
-#' @family reading
-#'
-#' @seealso
-#'
-#' [cff_read_bib()] for reading `*.bib` files.
-#'
-#' @export
-#' @encoding UTF-8
-#'
 #' @param x A `character` vector with one or more complete BibTeX entries.
 #' @param encoding Encoding to be assumed for `x`. See [readLines()].
 #' @param ... Arguments passed to [cff_read_bib()].
 #'
 #' @return
-#'
 #' An object of classes [`cff_ref_lst, cff`][cff_ref_lst] according to the
-#' `definitions.references` specified in
-#' the
+#' `definitions.reference` specified in the
 #' ```{r, echo=FALSE, results='asis'}
 #'
 #' cat(paste0(" [Citation File Format schema]",
@@ -34,13 +22,19 @@
 #' [`cff_ref, cff`][cff_ref].
 #'
 #' @details
-#'
 #' This function writes `x` to a temporary `*.bib` file and reads it using
 #' [cff_read_bib()].
 #'
 #' This function requires \CRANpkg{bibtex} (>= 0.5.0) and uses
 #' [bibtex::read.bib()] for parsing.
 #'
+#' @seealso
+#' [cff_read_bib()] for reading `*.bib` files.
+#'
+#' @family bibtex
+#' @family reading
+#' @export
+#' @encoding UTF-8
 #' @examples
 #' if (requireNamespace("bibtex", quietly = TRUE)) {
 #'   x <- c(
@@ -65,7 +59,7 @@
 #'   cff_read_bib_text(x)
 #' }
 cff_read_bib_text <- function(x, encoding = "UTF-8", ...) {
-  # Validations
+  # Validate input.
   if (!inherits(x, "character")) {
     cli::cli_abort(paste0(
       "{.arg x} should be a {.cls character}, not a ",
@@ -74,20 +68,20 @@ cff_read_bib_text <- function(x, encoding = "UTF-8", ...) {
   }
 
   if (any(grepl("\\.bib$", x, ignore.case = TRUE))) {
-    cli::cli_alert_warning(paste0(
+    cli::cli_alert_warning(
       "{.arg x} seems to be a {.val .bib} file, not a BibTeX entry."
-    ))
-    cli::cli_alert_info("Reading {.arg x} with {.fn cffr:cff_read_bib}")
+    )
+    cli::cli_alert_info("Reading {.arg x} with {.fn cffr:cff_read_bib}.")
     the_cff <- cff_read_bib(x, encoding = encoding, ...)
     return(the_cff)
   }
 
   if (!any(grepl("^@", x))) {
-    cli::cli_alert_warning(paste0(
+    cli::cli_alert_warning(
       "{.arg x} does not look like a BibTeX entry. Check the results."
-    ))
+    )
   }
-  # Write x to a tempfile
+  # Write `x` to a temporary file.
   file <- tempfile(fileext = ".bib")
   writeLines(x, file)
   the_cff <- cff_read_bib(file, encoding = encoding, ...)

--- a/R/cff_validate.R
+++ b/R/cff_validate.R
@@ -9,12 +9,21 @@
 #'            "citation-file-format/blob/main/schema.json)."))
 #'
 #' ```
-#' @export
-#' @encoding UTF-8
 #'
-#' @family core
+#' @param x A full `cff` object created with [cff_create()] or the path to a
+#'   `CITATION.cff` file to be validated. A `*.cff` file is read with
+#'   [cff_read_cff_citation()].
+#' @inheritParams cff_write
+#'
+#' @return
+#' A message indicating the result of the validation and an invisible value
+#' `TRUE/FALSE`. On error, the result has an attribute `"errors"` containing
+#' the error summary. See **Examples** and [attr()].
 #'
 #' @seealso
+#' [jsonvalidate::json_validate()], which is the function that performs the
+#' validation.
+#'
 #' ```{r, echo=FALSE, results='asis'}
 #'
 #' cat(paste0("[Guide to Citation File Format schema version 1.2.0]",
@@ -23,21 +32,9 @@
 #'
 #' ```
 #'
-#' @return
-#'
-#' A message indicating the result of the validation and an invisible value
-#' `TRUE/FALSE`. On error, the result has an attribute `"errors"`
-#' containing the error summary (see **Examples** and [attr()]).
-#'
-#' @param x This is expected to be either a full `cff` object created
-#'   with [cff_create()] or the path to a `CITATION.cff` file to be validated.
-#'   In the case of a `*.cff` file it would read with [cff_read_cff_citation()].
-#' @inheritParams cff_write
-#'
-#' @seealso
-#' [jsonvalidate::json_validate()], which is the function that performs the
-#' validation.
-#'
+#' @family core
+#' @export
+#' @encoding UTF-8
 #' @examples
 #' \donttest{
 #' # Full `.cff` example.
@@ -114,7 +111,7 @@ cff_validate <- function(x = "CITATION.cff", verbose = TRUE) {
         collapse = ""
       )
       cli::cli_alert_danger(paste0(
-        "Oops! ",
+        "Validation failed. ",
         is_a,
         " has the following errors:\n",
         ll
@@ -132,7 +129,7 @@ cff_validate <- function(x = "CITATION.cff", verbose = TRUE) {
 
   if (verbose) {
     cli::cat_rule("Validating cff", col = "cyan", line = 2)
-    cli::cli_alert_success(paste0("Congratulations! ", is_a, " is valid."))
+    cli::cli_alert_success(paste0(is_a, " is valid."))
   }
   invisible(result)
 }

--- a/R/cff_write.R
+++ b/R/cff_write.R
@@ -1,41 +1,34 @@
 #' Write a `CITATION.cff` file
 #'
 #' @description
-#'
 #' **This is the core function of the package and likely to be the only one
-#' you would need when developing a package**.
+#' you need when developing a package**.
 #'
-#' This function writes out a `CITATION.cff` file for a given package. This
-#' function is basically a wrapper around [cff_create()] to both create the
-#' [`cff`] object and write it out to a YAML-formatted file in
-#' one command.
-#'
-#' @family writing
+#' This function writes a `CITATION.cff` file for a given package. It wraps
+#' [cff_create()] to create the [`cff`] object and write it to a YAML-formatted
+#' file in one command.
 #'
 #' @param outfile The name and path of the `CITATION.cff` to be created.
-#'
 #' @param r_citation Logical `TRUE/FALSE`. When `TRUE`, the \R package
 #'   citation (for example, `inst/CITATION`) is created or updated.
 #'   **No backup copy is created**. For more control, use
 #'   [cff_write_citation()].
-#'
 #' @param verbose Logical `TRUE/FALSE`. When `TRUE`, the function displays
 #'   informative messages.
-#'
 #' @param validate Logical `TRUE/FALSE`. Should the new file be validated
 #'   using `cff_validate()`?
-#'
 #' @param encoding The name of the encoding to be assumed. Default is `"UTF-8"`,
 #'   but it can be any other value as accepted by [iconv()], such as
 #'   `"ASCII//TRANSLIT"`.
-#'
 #' @inheritParams cff_create
-#' @inheritParams cff_validate
-#'
-#' @export
-#' @encoding UTF-8
 #'
 #' @return A `CITATION.cff` file and an (invisible) `cff` object.
+#'
+#' @details
+#' For details of `authors_roles`, see [cff_create()].
+#'
+#' When creating and writing a `CITATION.cff` for the first time, this function
+#' adds the pattern `"^CITATION\.cff$"` to your `.Rbuildignore` file.
 #'
 #' @seealso
 #' ```{r, echo=FALSE, results='asis'}
@@ -48,6 +41,9 @@
 #' This function unifies the workflow [cff_create()] + [cff_validate()] +
 #' write a file.
 #'
+#' @family writing
+#' @export
+#' @encoding UTF-8
 #' @examples
 #' \donttest{
 #' tmpfile <- tempfile(fileext = ".cff")
@@ -58,13 +54,6 @@
 #' # Force clean-up
 #' file.remove(tmpfile)
 #' }
-#' @details
-#'
-#' For details of `authors_roles`, see [cff_create()].
-#'
-#' When creating and writing a `CITATION.cff` for the first time, the function
-#' adds the pattern `"^CITATION\.cff$"` to your `.Rbuildignore` file.
-#'
 cff_write <- function(
   x,
   outfile = "CITATION.cff",
@@ -98,7 +87,7 @@ cff_write <- function(
     authors_roles = authors_roles
   )
 
-  # Fix string if it is not cff.
+  # Ensure the output file uses a `.cff` extension.
   if (!is_substring(outfile, ".cff$")) {
     outfile <- paste0(outfile, ".cff")
   }
@@ -152,7 +141,7 @@ cff_write <- function(
     cff_validate(outfile, verbose)
   }
 
-  # Issue #79
+  # Update `inst/CITATION` when requested.
   auto_r_citation(r_citation = r_citation, outfile = outfile, verbose = verbose)
 
   invisible(citat)

--- a/R/cff_write_misc.R
+++ b/R/cff_write_misc.R
@@ -1,7 +1,6 @@
 #' Export \R objects to different file types
 #'
 #' @description
-#'
 #' Export \R objects representing citations to specific file formats:
 #' - [cff_write_bib()] creates a `.bib` file.
 #' - [cff_write_citation()] creates an \R citation file as described in
@@ -17,27 +16,19 @@
 #' @inheritDotParams as_bibentry.cff_ref
 #' @inheritDotParams as_bibentry.cff_ref_lst
 #'
-#' @references
-#'
-#' - R Core Team (2023). _Writing R Extensions_.
-#'   <https://cran.r-project.org/doc/manuals/r-release/R-exts.html>
-#'
-#' @export
-#' @encoding UTF-8
-#' @rdname cff_write_misc
-#' @family bibtex
-#' @family writing
-#'
 #' @return
 #' Writes the corresponding file specified on the `file` argument.
 #'
 #' @details
-#'
 #' When `x` is a `cff` object, it is converted to BibTeX using
 #' [toBibtex.cff()].
 #'
 #' For security reasons, if the file already exists, the function creates
 #' a backup copy in the same directory.
+#'
+#' @references
+#' - R Core Team (2023). _Writing R Extensions_.
+#'   <https://cran.r-project.org/doc/manuals/r-release/R-exts.html>
 #'
 #' @seealso
 #' `vignette("bibtex-cff", package = "cffr")`, [knitr::write_bib()] and the
@@ -46,8 +37,12 @@
 #' - \CRANpkg{RefManageR}
 #' - \CRANpkg{rbibutils}
 #'
+#' @family bibtex
+#' @family writing
+#' @export
+#' @encoding UTF-8
+#' @rdname cff_write_misc
 #' @examples
-#'
 #' bib <- bibentry("Misc",
 #'   title = "My title",
 #'   author = "Fran Pérez"
@@ -70,21 +65,12 @@ cff_write_bib <- function(
   ascii = FALSE,
   ...
 ) {
-  if (inherits(x, "cff")) {
-    x <- as_bibentry(x, ...)
-  }
-
-  if (!inherits(x, "bibentry")) {
-    cli::cli_abort(paste0(
-      "{.arg x} should be a {.cls bibentry} object, not a ",
-      "{.cls {class(x)}} object."
-    ))
-  }
+  x <- cff_coerce_bibentry(x, ...)
 
   btex <- toBibtex(x)
 
   if (ascii) {
-    # Base encoding as per file()
+    # Use base encoding as in `file()`.
     btex <- encoded_utf_to_latex(btex)
     class(btex) <- "Bibtex"
   } else {
@@ -103,17 +89,15 @@ cff_write_bib <- function(
 #' @rdname cff_write_misc
 #' @name cff_write_citation
 #' @examples
-#'
-#' # Create a CITATION file
-#'
-#' # Use a system file
+#' # Create a CITATION file.
+#' # Use a system file.
 #' f <- system.file("examples/preferred-citation-book.cff", package = "cffr")
 #' a_cff <- cff_read(f)
 #'
 #' out <- file.path(tempdir(), "CITATION")
 #' cff_write_citation(a_cff, file = out)
 #'
-#' # Check by reading, use meta object
+#' # Check by reading with a meta object.
 #' meta <- packageDescription("cffr")
 #' meta$Encoding <- "UTF-8"
 #'
@@ -125,19 +109,30 @@ cff_write_citation <- function(
   verbose = TRUE,
   ...
 ) {
-  if (inherits(x, "cff")) {
-    x <- as_bibentry(x, ...)
-  }
-
-  if (!inherits(x, "bibentry")) {
-    cli::cli_abort(paste0(
-      "{.arg x} should be a {.cls bibentry} object, not a ",
-      "{.cls {class(x)}} object."
-    ))
-  }
+  x <- cff_coerce_bibentry(x, ...)
 
   bentr <- format(x, style = "R")
   bentr <- c("", bentr)
   write_lines_msg(bentr, file, verbose, append)
   invisible(NULL)
+}
+
+cff_coerce_bibentry <- function(x, ...) {
+  error_call <- parent.frame()
+
+  if (inherits(x, "cff")) {
+    x <- as_bibentry(x, ...)
+  }
+
+  if (!inherits(x, "bibentry")) {
+    cli::cli_abort(
+      paste0(
+        "{.arg x} should be a {.cls bibentry} object, not a ",
+        "{.cls {class(x)}} object."
+      ),
+      call = error_call
+    )
+  }
+
+  x
 }

--- a/R/data.R
+++ b/R/data.R
@@ -1,14 +1,8 @@
 #' Mapping between `License` fields and SPDX
 #'
 #' A dataset containing the mapping between the `License` strings observed
-#' on CRAN packages and its (approximate) match on the
+#' on CRAN packages and their approximate match on the
 #' [SPDX License List](https://spdx.org/licenses/).
-#'
-#' @family datasets
-#' @docType data
-#' @encoding UTF-8
-#' @name cran_to_spdx
-#' @rdname cran_to_spdx
 #'
 #' @format
 #' A data frame with `r nrow(cran_to_spdx)` rows and 2 variables:
@@ -28,8 +22,12 @@
 #'
 #' @source <https://spdx.org/licenses/>
 #'
+#' @family datasets
+#' @docType data
+#' @encoding UTF-8
+#' @name cran_to_spdx
+#' @rdname cran_to_spdx
 #' @examples
-#'
 #' data("cran_to_spdx")
 #'
 #' head(cran_to_spdx, 20)

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -3,22 +3,23 @@
 #' @description
 #' `r lifecycle::badge('deprecated')` Please use [as_bibentry()] instead.
 #'
-#' @rdname deprecated_cff_to_bib
 #' @inheritParams as_bibentry
-#' @export
-#' @encoding UTF-8
-#' @keywords internal
-#' @family deprecated
 #'
 #' @return See [as_bibentry()].
+#'
+#' @family deprecated
+#' @export
+#' @encoding UTF-8
+#' @rdname deprecated_cff_to_bib
+#' @keywords internal
 #' @examples
 #' \donttest{
-#' # From a cff object
+#' # From a cff object.
 #' cff_object <- cff()
 #'
 #' cff_object
 #'
-#' # bibentry object
+#' # A bibentry object.
 #' bib <- as_bibentry(cff_object)
 #' }
 cff_extract_to_bibtex <- function(
@@ -53,28 +54,24 @@ cff_to_bibtex <- function(x, what = c("preferred", "references", "all")) {
 #' Previous API: Create a [`cff`] object from BibTeX entries
 #'
 #' @description
-#'
 #' `r lifecycle::badge('deprecated')` Please use either [cff_read_bib()] or
 #' [cff_read_bib_text()] instead.
-#'
-#' @rdname deprecated_cff_from_bib
-#' @export
-#' @encoding UTF-8
-#' @keywords internal
-#' @family deprecated
 #'
 #' @param x The source used to generate the
 #'   [`cff`] object. Must be a `character` object indicating either:
 #'   - The path to a BibTeX file.
 #'   - A vector of characters with a complete BibTeX string. See **Examples**.
-#' @param encoding Encoding to be assumed for `x`. See [readLines()].
-#' @param ... Other arguments passed to [bibtex::read.bib()].
+#' @inheritParams cff_read_bib_text
 #'
 #' @return
-#'
 #' See [cff_read_bib()] for reading `*.bib` files and [cff_read_bib_text()]
 #' for reading a `character` object representing a BibTeX entry.
 #'
+#' @family deprecated
+#' @export
+#' @encoding UTF-8
+#' @rdname deprecated_cff_from_bib
+#' @keywords internal
 #' @examples
 #' if (requireNamespace("bibtex", quietly = TRUE)) {
 #'   x <- c(
@@ -98,7 +95,7 @@ cff_to_bibtex <- function(x, what = c("preferred", "references", "all")) {
 #'
 #'   cff_read_bib_text(x)
 #'
-#'   # From a file
+#'   # From a file.
 #'
 #'   x2 <- system.file("examples/example.bib", package = "cffr")
 #'   cff_read_bib(x2)
@@ -109,7 +106,7 @@ cff_from_bibtex <- function(x, encoding = "UTF-8", ...) {
       lifecycle::deprecate_warn("1.0.0", "cff_from_bibtex()", "cff_read_bib()")
     }
 
-    # Read bib file
+    # Read the BibTeX file.
     return(cff_read_bib(x, encoding = encoding, ...))
   }
 
@@ -126,25 +123,23 @@ cff_from_bibtex <- function(x, encoding = "UTF-8", ...) {
 #' Previous API: Write files
 #'
 #' @description
-#'
 #' `r lifecycle::badge('deprecated')` Please use [cff_write_bib()] or
 #' [cff_write_citation()] instead.
 #'
-#' @rdname deprecated_write
-#' @export
-#' @encoding UTF-8
-#' @keywords internal
-#' @family deprecated
 #' @inheritParams cff_write_bib
 #'
-#' @return Write a file.
+#' @return Writes a file.
 #'
 #' @seealso
 #' - [cff_write_bib()] for writing `*.bib` files.
 #' - [cff_write_citation()] for writing \R `CITATION` files.
 #'
+#' @family deprecated
+#' @export
+#' @encoding UTF-8
+#' @rdname deprecated_write
+#' @keywords internal
 #' @examples
-#'
 #' bib <- bibentry("Misc",
 #'   title = "My title",
 #'   author = "Fran Pérez"
@@ -196,14 +191,8 @@ write_citation <- function(
 #' Previous API: Parse a `person` to [`cff`]
 #'
 #' @description
+#' `r lifecycle::badge('deprecated')` Please use [as_cff_person()] instead.
 #'
-#' `r lifecycle::badge('deprecated')` Please use [as_cff_person()]
-#'
-#' @rdname deprecated_cff_person
-#' @export
-#' @encoding UTF-8
-#' @keywords internal
-#' @family deprecated
 #' @param person It can be either:
 #'   - A `person` or list of `person` object created with [utils::person()].
 #'   - A `character` object or vector representing a person or persons.
@@ -212,8 +201,13 @@ write_citation <- function(
 #'
 #' @seealso [as_cff_person()]
 #'
+#' @family deprecated
+#' @export
+#' @encoding UTF-8
+#' @rdname deprecated_cff_person
+#' @keywords internal
 #' @examples
-#' # Create a person object
+#' # Create a person object.
 #' a_person <- person(
 #'   given = "First", family = "Author",
 #'   role = c("aut", "cre"),
@@ -229,22 +223,22 @@ write_citation <- function(
 #'
 #' cff_person
 #'
-#' # Back to person object with S3 method
+#' # Back to person object with S3 method.
 #' as.person(cff_person)
 #'
-#' # Parse a string
+#' # Parse a string.
 #' a_str <- paste0(
 #'   "Julio Iglesias <fake@email.com> ",
 #'   "(<https://orcid.org/0000-0001-8457-4658>)"
 #' )
 #' as_cff_person(a_str)
 #'
-#' # Several persons
+#' # Several persons.
 #' persons <- c(person("Clark", "Kent"), person("Lois", "Lane"))
 #'
 #' as_cff_person(persons)
 #'
-#' # Or you can use BibTeX style if you prefer
+#' # Or use BibTeX style.
 #'
 #' x <- "Frank Sinatra and Dean Martin and Davis, Jr., Sammy and Joey Bishop"
 #'
@@ -276,26 +270,24 @@ cff_parse_person_bibtex <- function(person) {
 #' Previous API: Parse a `bibentry` to `cff`
 #'
 #' @description
-#'
-#' `r lifecycle::badge('deprecated')` Please use [as_cff.bibentry()] method
-#'
-#' @rdname deprecated_cff_bibentry
-#' @export
-#' @encoding UTF-8
-#' @keywords internal
-#' @family deprecated
+#' `r lifecycle::badge('deprecated')` Please use the [as_cff.bibentry()]
+#' method instead.
 #'
 #' @param bib A `bibentry` object.
 #' @return A `bibentry` in format [`cff`].
 #'
 #' @seealso [as_cff.bibentry()]
 #'
+#' @family deprecated
+#' @export
+#' @encoding UTF-8
+#' @rdname deprecated_cff_bibentry
+#' @keywords internal
 #' @examples
-#'
 #' bib <- citation("base")
 #' bib
 #'
-#' # To cff
+#' # To cff.
 #' bib_to_cff <- as_cff(bib)
 #' bib_to_cff
 #'

--- a/R/docs.R
+++ b/R/docs.R
@@ -1,15 +1,8 @@
 #' The `cff` class
-#' @encoding UTF-8
-#'
-#' @rdname cff_class
-#' @name cff_class
-#' @aliases cff_ref cff_ref_lst cff_pers cff_pers_lst
-#'
-#' @keywords internal
-#'
-#' @family s3method
 #'
 #' @description
+#' \CRANpkg{cffr} implements an S3 object with [`class`] `cff`, which represents
+#' the information in a `CITATION.cff` file in \R.
 #'
 #' ```{r child = "man/chunks/cffclass.Rmd"}
 #' ```
@@ -19,4 +12,11 @@
 #' - Wickham H (2019). "S3." In _Advanced R_, 2nd edition.
 #'   Chapman and Hall/CRC. \doi{10.1201/9781351201315},
 #'   <https://adv-r.hadley.nz/s3.html>.
+#'
+#' @family s3method
+#' @encoding UTF-8
+#' @rdname cff_class
+#' @name cff_class
+#' @aliases cff_ref cff_ref_lst cff_pers cff_pers_lst
+#' @keywords internal
 NULL

--- a/R/encoded_utf_to_latex.R
+++ b/R/encoded_utf_to_latex.R
@@ -3,27 +3,25 @@
 #' @description
 #' Transform a UTF-8 string into LaTeX special characters.
 #'
-#' @return A string with the corresponding transformations.
-#'
-#' @param x A string, possibly encoded in UTF-8 encoding system.
-#'
-#' @family bibtex
-#'
-#' @seealso [tools::encoded_text_to_latex()]
+#' @param x A string, possibly encoded in UTF-8.
 #'
 #' @importFrom tools encoded_text_to_latex
 #'
-#' @details
+#' @return A string with the corresponding transformations.
 #'
+#' @details
 #' This is a variation of [tools::encoded_text_to_latex()] with some
 #' additional replacements for better compatibility.
 #'
+#' @seealso [tools::encoded_text_to_latex()]
+#'
+#' @family bibtex
 #' @keywords internal
 #' @export
 #' @encoding UTF-8
 #'
 #' @examples
-#' # Full range of supported characters on R
+#' # Full range of supported characters in R.
 #' library(tools)
 #'
 #' range <- 1:511
@@ -33,12 +31,12 @@
 #'   utf8 = intToUtf8(range, multiple = TRUE)
 #' )
 #'
-#' # Add latex using base approach
+#' # Add LaTeX using the base approach.
 #' ascii_table$latex_base <- encoded_text_to_latex(ascii_table$utf8,
 #'   encoding = "UTF-8"
 #' )
 #'
-#' # With cffr
+#' # With cffr.
 #' ascii_table$latex_cffr <- encoded_utf_to_latex(ascii_table$utf8)
 #'
 #' ascii_table

--- a/R/methods.R
+++ b/R/methods.R
@@ -54,14 +54,11 @@ as.data.frame.cff <- function(x, row.names = NULL, optional = FALSE, ...) {
   # For better dispatching.
   x <- as_cff(as.list(x))
 
-  len <- length(x)
-  key_len <- seq_len(len)
   ref_n <- names(x)
 
-  df_l <- lapply(key_len, function(y) {
+  df_l <- lapply(seq_along(x), function(y) {
     el <- x[[y]]
-    nm <- ref_n[y]
-    nm <- gsub("-", "_", nm, fixed = TRUE)
+    nm <- cff_df_name(ref_n[y])
 
     if (nm == "preferred_citation") {
       return(as.data.frame(el, prefix = nm))
@@ -89,9 +86,7 @@ as.data.frame.cff <- function(x, row.names = NULL, optional = FALSE, ...) {
     df
   })
 
-  the_df <- do.call(cbind, df_l)
-
-  as.data.frame(the_df, row.names = row.names, optional = optional, ...)
+  cff_df_bind(df_l, row.names = row.names, optional = optional, ...)
 }
 
 #' @export
@@ -105,22 +100,7 @@ as.data.frame.cff_pers_lst <- function(
   ...,
   prefix = "person"
 ) {
-  # For better dispatching.
-  x <- as_cff(as.list(x))
-
-  len <- length(x)
-  key_len <- seq_len(len)
-
-  df_l <- lapply(key_len, function(y) {
-    prefix <- paste0(prefix, ".", sprintf("%02d", y - 1))
-    el <- x[[y]]
-    df <- as.data.frame(el, prefix = prefix)
-    df
-  })
-
-  the_df <- do.call(cbind, df_l)
-
-  as.data.frame(the_df, row.names = row.names, optional = optional, ...)
+  cff_df_indexed(x, prefix, row.names, optional, ...)
 }
 
 #' @export
@@ -138,14 +118,11 @@ as.data.frame.cff_pers <- function(
   x <- as_cff(as.list(x))
 
   vals <- unlist(x)
-  nm <- names(vals)
-  nm <- gsub("-", "_", nm, fixed = TRUE)
+  nm <- cff_df_name(names(vals))
   amat <- matrix(vals, nrow = 1, ncol = length(vals))
   m <- as.data.frame(amat)
 
-  if (!is.null(clean_str(prefix))) {
-    nm <- paste0(prefix, ".", nm)
-  }
+  nm <- cff_df_prefix(nm, prefix)
 
   names(m) <- nm
   m
@@ -164,28 +141,15 @@ as.data.frame.cff_ref_lst <- function(
   ...,
   prefix = "references"
 ) {
-  # For better dispatching
-  x <- as_cff(as.list(x))
-
-  len <- length(x)
-  key_len <- seq_len(len)
-
-  df_l <- lapply(key_len, function(y) {
-    prefix <- paste0(prefix, ".", sprintf("%02d", y - 1))
-    el <- x[[y]]
-    df <- as.data.frame(
-      el,
-      row.names = row.names,
-      optional = optional,
-      ...,
-      prefix = prefix
-    )
-    df
-  })
-
-  the_df <- do.call(cbind, df_l)
-
-  as.data.frame(the_df, row.names = row.names, optional = optional, ...)
+  cff_df_indexed(
+    x,
+    prefix,
+    row.names,
+    optional,
+    ...,
+    element_args = list(row.names = row.names, optional = optional),
+    element_dots = TRUE
+  )
 }
 
 #' @export
@@ -211,6 +175,56 @@ as.data.frame.cff_ref <- function(
   }
 
   the_df
+}
+
+cff_df_indexed <- function(
+  x,
+  prefix,
+  row.names,
+  optional,
+  ...,
+  element_args = list(),
+  element_dots = FALSE
+) {
+  # For better dispatching.
+  x <- as_cff(as.list(x))
+  dots <- list(...)
+
+  df_l <- lapply(seq_along(x), function(y) {
+    element_prefix <- cff_df_index_prefix(prefix, y)
+    args <- c(list(x[[y]], prefix = element_prefix), element_args)
+    if (element_dots) {
+      args <- c(args, dots)
+    }
+    do.call(as.data.frame, args)
+  })
+
+  args <- c(
+    list(df_l = df_l, row.names = row.names, optional = optional),
+    dots
+  )
+  do.call(cff_df_bind, args)
+}
+
+cff_df_bind <- function(df_l, row.names = NULL, optional = FALSE, ...) {
+  the_df <- do.call(cbind, df_l)
+  as.data.frame(the_df, row.names = row.names, optional = optional, ...)
+}
+
+cff_df_index_prefix <- function(prefix, index) {
+  paste0(prefix, ".", sprintf("%02d", index - 1))
+}
+
+cff_df_prefix <- function(nm, prefix) {
+  if (!is.null(clean_str(prefix))) {
+    return(paste0(prefix, ".", nm))
+  }
+
+  nm
+}
+
+cff_df_name <- function(nm) {
+  gsub("-", "_", nm, fixed = TRUE)
 }
 # nolint end
 

--- a/R/utils-alerts.R
+++ b/R/utils-alerts.R
@@ -41,7 +41,7 @@ match_cff_arg <- function(arg, valid, for_msg, call = environment()) {
 
   if (!arg %in% valid) {
     cli::cli_abort(
-      "{.arg {for_msg}} should be {.or  {.val {valid}}}, not {.val {arg}}.",
+      "{.arg {for_msg}} should be {.or {.val {valid}}}, not {.val {arg}}.",
       call = call
     )
   }
@@ -75,7 +75,7 @@ write_lines_msg <- function(lines, file, verbose, append) {
   fh <- file(file, encoding = "UTF-8", open = ifelse(append, "a+", "w+"))
   on.exit(if (isOpen(fh)) close(fh))
   if (verbose) {
-    cli::cli_alert_info("Writing {length(lines[lines != ''])} entr{?y/ies} ...")
+    cli::cli_alert_info("Writing {length(lines[lines != ''])} entr{?y/ies}.")
   }
 
   writeLines(lines, fh)

--- a/R/utils-cff_read.R
+++ b/R/utils-cff_read.R
@@ -274,6 +274,10 @@ desc_url_identifiers <- function(urls) {
   })
 }
 
+desc_gh_keywords <- function(desc_keywords, gh_topics) {
+  unique(c(desc_keywords, gh_topics))
+}
+
 #' Mapped to Version
 #' @noRd
 get_desc_version <- function(pkg) {
@@ -294,13 +298,26 @@ get_gh_topics <- function(x) {
   }
 
   # Get topics from the repository.
-  api_url <- paste0(
-    "https://api.github.com/repos",
-    "/",
-    gsub("^http[a-z]://github.com/", "", x["repository-code"])
-  )
+  api_url <- gh_topics_api_url(x)
+  topics <- fetch_gh_topics(api_url)
 
-  tmpfile <- tempfile(fileext = ".json")
+  if (is.null(topics)) {
+    return(NULL)
+  }
+
+  remotetopics <- lapply(topics, clean_str)
+  remotetopics <- unique(unlist(remotetopics))
+
+  # If there are no topics, return NULL.
+  if (length(remotetopics) == 0) {
+    return(NULL)
+  }
+
+  remotetopics
+}
+
+fetch_gh_topics <- function(api_url, tmpfile = tempfile(fileext = ".json")) {
+  # nocov start
 
   # Check whether GH_TOKEN is set in Renviron.
   # Tests can quickly reach the GitHub API limit without authentication.
@@ -310,8 +327,6 @@ get_gh_topics <- function(x) {
   token <- token[!token %in% c(NA, NULL, "")][1]
 
   ghtoken <- paste("token", token)
-
-  # nocov start
 
   # Try with GITHUB_TOKEN.
   res <- tryCatch(
@@ -344,20 +359,20 @@ get_gh_topics <- function(x) {
     )
   }
 
-  # nocov end
   if (isTRUE(res)) {
     return(NULL)
   }
 
-  remotetopics <- lapply(jsonlite::read_json(tmpfile)$topics, clean_str)
-  remotetopics <- unique(unlist(remotetopics))
+  jsonlite::read_json(tmpfile)$topics
+  # nocov end
+}
 
-  # If there are no topics, return NULL.
-  if (is.null(remotetopics)) {
-    return(NULL) # nocov
-  }
-
-  remotetopics
+gh_topics_api_url <- function(x) {
+  paste0(
+    "https://api.github.com/repos",
+    "/",
+    gsub("^http[a-z]://github.com/", "", x["repository-code"])
+  )
 }
 
 get_desc_sha <- function(pkg) {

--- a/R/utils-cff_read.R
+++ b/R/utils-cff_read.R
@@ -157,29 +157,29 @@ get_desc_repository <- function(pkg) {
   name <- pkg$get("Package")
   repo <- clean_str(pkg$get("Repository"))
 
-  # Repository is a URL.
   if (is_url(repo)) {
     return(repo)
   }
 
-  # Check if Bioconductor.
-  # biocViews is required in Bioconductor packages.
-  # http://contributions.bioconductor.org/description.html#biocviews
-  if (!is.null(clean_str(pkg$get("biocViews")))) {
+  if (is_bioconductor_desc(pkg)) {
     return("https://bioconductor.org/")
   }
 
-  # Repository is CRAN.
-  # Canonical URL to CRAN.
   if (is_substring(repo, "^CRAN$")) {
-    return(paste0("https://CRAN.R-project.org/package=", name))
+    return(cran_package_url(name))
   }
 
-  # Otherwise, search installed repositories.
+  search_on_repos(name)
+}
 
-  repourl <- search_on_repos(name)
+is_bioconductor_desc <- function(pkg) {
+  # biocViews is required in Bioconductor packages.
+  # http://contributions.bioconductor.org/description.html#biocviews
+  !is.null(clean_str(pkg$get("biocViews")))
+}
 
-  repourl
+cran_package_url <- function(name) {
+  paste0("https://CRAN.R-project.org/package=", name)
 }
 
 #' Mapped to Package and Title
@@ -196,28 +196,53 @@ get_desc_title <- function(pkg) {
 #' @noRd
 get_desc_urls <- function(pkg) {
   url <- pkg$get_urls()
-
-  # Get issue URL.
-  issues <- tryCatch(pkg$get_field("BugReports")[1], error = function(cond) {
-    pkg$get_urls()
-  })
-
-  # Clean if GitLab.
-  issues <- gsub("/-/issues$", "", issues)
-  # Clean if GitHub and codeberg.org.
-  issues <- gsub("/issues$", "", issues)
-
-  # Join issues and URLs.
-  allurls <- unique(c(issues, url))
-  allurls <- allurls[is_url(allurls)]
+  allurls <- desc_all_urls(pkg, url)
 
   # If there are no URLs, return as null.
   if (length(allurls) == 0) {
-    url_list <- list(url = NULL)
-    return(url_list)
+    return(list(url = NULL))
   }
-  # Try to find a repository URL.
-  domains <- paste0(
+
+  # Extract repository URL.
+  repo_line <- desc_repository_url_index(allurls)
+  repository_code <- clean_str(allurls[repo_line][1])
+
+  if (!is.na(repo_line)) {
+    remaining <- allurls[-repo_line]
+  } else {
+    remaining <- allurls
+  }
+
+  url_data <- desc_primary_url(remaining, repository_code)
+
+  list(
+    repo = clean_str(repository_code),
+    url = url_data$url,
+    identifiers = desc_url_identifiers(url_data$remaining)
+  )
+}
+
+desc_all_urls <- function(pkg, url = pkg$get_urls()) {
+  issues <- tryCatch(pkg$get_field("BugReports")[1], error = function(cond) {
+    pkg$get_urls()
+  })
+  issues <- desc_clean_issue_url(issues)
+
+  allurls <- unique(c(issues, url))
+  allurls[is_url(allurls)]
+}
+
+desc_clean_issue_url <- function(issues) {
+  issues <- gsub("/-/issues$", "", issues)
+  gsub("/issues$", "", issues)
+}
+
+desc_repository_url_index <- function(urls) {
+  grep(desc_repository_domains(), urls, ignore.case = TRUE)[1]
+}
+
+desc_repository_domains <- function() {
+  paste0(
     c(
       "github.com",
       "www.github.com",
@@ -228,43 +253,25 @@ get_desc_urls <- function(pkg) {
     ),
     collapse = "|"
   )
+}
 
-  # Extract repository URL.
-  repo_line <- grep(domains, allurls, ignore.case = TRUE)[1]
-
-  repository_code <- clean_str(allurls[repo_line][1])
-
-  if (!is.na(repo_line)) {
-    remaining <- allurls[-repo_line]
-  } else {
-    remaining <- allurls
-  }
-
+desc_primary_url <- function(remaining, repository_code) {
   # The second URL is considered for URL arbitrarily.
   if (isTRUE(length(remaining) > 0)) {
-    url_end <- remaining[1]
-    remaining <- remaining[-1]
-  } else {
-    url_end <- repository_code
-  }
-  url_end <- clean_str(url_end)
-
-  # If there are more, move them to identifiers.
-
-  if (isTRUE(length(remaining) > 0)) {
-    identifiers <- lapply(remaining, function(x) {
-      list(type = "url", value = clean_str(x))
-    })
-  } else {
-    identifiers <- NULL
+    return(list(url = clean_str(remaining[1]), remaining = remaining[-1]))
   }
 
-  url_list <- list(
-    repo = clean_str(repository_code),
-    url = clean_str(url_end),
-    identifiers = identifiers
-  )
-  url_list
+  list(url = clean_str(repository_code), remaining = remaining)
+}
+
+desc_url_identifiers <- function(urls) {
+  if (!isTRUE(length(urls) > 0)) {
+    return(NULL)
+  }
+
+  lapply(urls, function(x) {
+    list(type = "url", value = clean_str(x))
+  })
 }
 
 #' Mapped to Version

--- a/R/utils-cff_read.R
+++ b/R/utils-cff_read.R
@@ -71,7 +71,7 @@ get_desc_date_released <- function(pkg) {
       return(NULL)
     }
     if (!is.character(x)) {
-      return(NULL)
+      return(NULL) # nocov
     }
     substr(x, 1, 10)
   })
@@ -354,7 +354,7 @@ get_gh_topics <- function(x) {
 
   # If there are no topics, return NULL.
   if (is.null(remotetopics)) {
-    return(NULL)
+    return(NULL) # nocov
   }
 
   remotetopics

--- a/R/utils-cff_ref.R
+++ b/R/utils-cff_ref.R
@@ -292,18 +292,7 @@ get_bibtex_doi <- function(cit_list) {
 
   dois <- unique(as.character(dois))
 
-  # The first DOI goes to the doi key.
-  doi <- unlist(dois[1])
-
-  # The rest go to identifiers.
-  identifiers <- lapply(dois[-1], function(x) {
-    list(type = "doi", value = clean_str(x))
-  })
-  if (length(identifiers) == 0) {
-    identifiers <- NULL
-  }
-  doi_list <- list(doi = clean_str(doi), identifiers = identifiers)
-  doi_list
+  cff_identifier_fields(dois, key = "doi", type = "doi")
 }
 
 #' Build the month field.
@@ -346,22 +335,25 @@ get_bibtex_url <- function(cit_list) {
   }
 
   allurls <- allurls[is_url(allurls)]
-  # The first URL goes to the url key.
+  cff_identifier_fields(allurls, key = "url", type = "url")
+}
 
-  url <- unlist(allurls[1])
-
-  # The rest go to identifiers.
-  identifiers <- lapply(allurls[-1], function(x) {
-    list(type = "url", value = clean_str(x))
+cff_identifier_fields <- function(values, key, type) {
+  main_value <- unlist(values[1])
+  identifiers <- lapply(values[-1], function(x) {
+    list(type = type, value = clean_str(x))
   })
 
   if (length(identifiers) == 0) {
     identifiers <- NULL
   }
 
-  url_list <- list(url = clean_str(url), identifiers = identifiers)
-
-  url_list
+  c(
+    stats::setNames(list(clean_str(main_value)), key),
+    list(
+      identifiers = identifiers
+    )
+  )
 }
 
 #' Build fields for additional people.

--- a/R/utils-create.R
+++ b/R/utils-create.R
@@ -191,8 +191,10 @@ cff_dependency_citation <- function(package) {
 }
 
 is_cran_dependency <- function(package) {
-  base_pkgs <- rownames(installed.packages(priority = "base"))
-  all(package %in% avail_on_init$Package, !package %in% base_pkgs)
+  avail <- get_avail_on_init()
+  base_packages <- rownames(installed.packages(priority = "base"))
+
+  all(package %in% avail$Package, !package %in% base_packages)
 }
 
 cff_dependency_desc_fields <- function(mod, package) {

--- a/R/utils-create.R
+++ b/R/utils-create.R
@@ -57,21 +57,11 @@ merge_desc_cit <- function(cffobj, citobj) {
 enhance_pref_authors <- function(cffobjend) {
   # Create an index of authors extracted from DESCRIPTION.
   auth_desc <- cffobjend$authors
-  key_aut_desc <- lapply(auth_desc, function(x) {
-    l <- list(x["family-names"], x["given-names"], x["name"])
-    l <- unlist(drop_null(l))
-    tolower(paste0(l, collapse = ""))
-  })
-  names(auth_desc) <- unlist(key_aut_desc)
+  names(auth_desc) <- cff_author_keys(auth_desc)
 
   # Create an index of authors from `preferred-citation`.
   auth_pref <- cffobjend$`preferred-citation`$authors
-  key_aut_cit <- lapply(auth_pref, function(x) {
-    l <- list(x["family-names"], x["given-names"], x["name"])
-    l <- unlist(drop_null(l))
-    tolower(paste0(l, collapse = ""))
-  })
-  names(auth_pref) <- unlist(key_aut_cit)
+  names(auth_pref) <- cff_author_keys(auth_pref)
 
   # Add missing keys to authors.
   enhancedauth <- lapply(names(auth_pref), function(x) {
@@ -91,6 +81,20 @@ enhance_pref_authors <- function(cffobjend) {
   enhancedauth
 }
 
+cff_author_keys <- function(authors) {
+  unlist(lapply(authors, cff_author_key))
+}
+
+cff_author_key <- function(author) {
+  key_parts <- list(
+    author["family-names"],
+    author["given-names"],
+    author["name"]
+  )
+  key_parts <- unlist(drop_null(key_parts))
+  tolower(paste0(key_parts, collapse = ""))
+}
+
 get_dependencies <- function(
   desc_path,
   instpack = as.character(installed.packages()[, "Package"])
@@ -106,100 +110,13 @@ get_dependencies <- function(
 
   getdeps <- desc::desc(desc_path)
 
-  deps <- getdeps$get_deps()
-
-  # Adapt the version.
-
-  deps$version_clean <- gsub("*", "", deps$version, fixed = TRUE)
-
-  # Save a copy for later.
-  origdeps <- deps
-
-  # Deduplicate rows.
-  deps <- unique(deps[, c("package", "version_clean")])
-
-  # Get the dependency type and add it to the scope.
-  scope <- vapply(
-    deps$package,
-    function(x) {
-      y <- origdeps[origdeps$package == x, "type"]
-
-      y[1]
-    },
-    FUN.VALUE = character(1)
-  )
-  deps$scope <- scope
+  deps <- cff_dependency_rows(getdeps$get_deps())
 
   av_deps <- deps[deps$package %in% c("R", instpack), ]
 
   # Get references from dependency DESCRIPTION files.
   cff_deps <- lapply(seq_len(nrow(av_deps)), function(y) {
-    n <- av_deps[y, ]
-
-    if (n$package == "R") {
-      mod <- as_cff(citation())[[1]]
-      mod$year <- format(Sys.Date(), "%Y")
-    } else {
-      mod <- try(
-        as_cff(citation(n$package, auto = TRUE)[1])[[1]],
-        silent = TRUE
-      )
-
-      if (inherits(mod, "try-error")) {
-        return(NULL) # nocov
-      }
-
-      # Simplify the `cff` object to avoid cluttering the output.
-      mod$abstract <- mod$title
-      mod$title <- n$package
-      # Add the CRAN DOI for non-base CRAN packages.
-      base_pkgs <- rownames(installed.packages(priority = "base"))
-
-      cran_doi <- all(
-        n$package %in% avail_on_init$Package,
-        !n$package %in% base_pkgs
-      )
-      if (cran_doi) {
-        mod$doi <- paste0("10.32614/CRAN.package.", n$package)
-      }
-    }
-
-    mod$type <- "software"
-    mod$version <- ifelse(is.na(n$version_clean), NULL, paste(n$version_clean))
-    # Get URL and repository from package DESCRIPTION.
-    # URLs from citation() vary due to auto = TRUE.
-    dfile <- system.file("DESCRIPTION", package = n$package)
-
-    if (file_exist_abort(dfile)) {
-      pkg <- desc::desc(dfile)
-      mod$url <- get_desc_urls(pkg)$url
-      mod$repository <- get_desc_repository(pkg)
-    }
-
-    mod <- drop_null(mod)
-
-    # Get the year.
-    date_rel <- mod[["date-released"]]
-
-    if (is.null(date_rel)) {
-      year <- format(Sys.Date(), "%Y")
-    } else {
-      year <- format(as.Date(date_rel), "%Y")
-    }
-
-    mod$year <- year
-    mod$notes <- clean_str(n$scope)
-
-    # Rearrange keys.
-    mod <- c(
-      mod[c("type", "title", "abstract", "notes", "url", "repository")],
-      mod[
-        !names(mod) %in%
-          c("type", "title", "abstract", "notes", "url", "repository")
-      ]
-    )
-
-    mod <- as_cff(mod)
+    cff_dependency_reference(av_deps[y, ])
   })
 
   cff_deps <- drop_null(cff_deps)
@@ -209,4 +126,100 @@ get_dependencies <- function(
   class(cff_deps) <- "cff"
 
   cff_deps
+}
+
+cff_dependency_rows <- function(deps) {
+  deps$version_clean <- gsub("*", "", deps$version, fixed = TRUE)
+
+  origdeps <- deps
+  deps <- unique(deps[, c("package", "version_clean")])
+  deps$scope <- vapply(
+    deps$package,
+    function(x) origdeps[origdeps$package == x, "type"][1],
+    FUN.VALUE = character(1)
+  )
+
+  deps
+}
+
+cff_dependency_reference <- function(dep) {
+  mod <- cff_dependency_citation(dep$package)
+
+  if (is.null(mod)) {
+    return(NULL) # nocov
+  }
+
+  mod$type <- "software"
+  mod$version <- ifelse(
+    is.na(dep$version_clean),
+    NULL,
+    paste(dep$version_clean)
+  )
+  mod <- cff_dependency_desc_fields(mod, dep$package)
+  mod <- drop_null(mod)
+  mod$year <- cff_dependency_year(mod)
+  mod$notes <- clean_str(dep$scope)
+
+  as_cff(cff_dependency_order(mod))
+}
+
+cff_dependency_citation <- function(package) {
+  if (package == "R") {
+    mod <- as_cff(citation())[[1]]
+    mod$year <- format(Sys.Date(), "%Y")
+    return(mod)
+  }
+
+  mod <- try(
+    as_cff(citation(package, auto = TRUE)[1])[[1]],
+    silent = TRUE
+  )
+
+  if (inherits(mod, "try-error")) {
+    return(NULL) # nocov
+  }
+
+  # Simplify the `cff` object to avoid cluttering the output.
+  mod$abstract <- mod$title
+  mod$title <- package
+
+  if (is_cran_dependency(package)) {
+    mod$doi <- paste0("10.32614/CRAN.package.", package)
+  }
+
+  mod
+}
+
+is_cran_dependency <- function(package) {
+  base_pkgs <- rownames(installed.packages(priority = "base"))
+  all(package %in% avail_on_init$Package, !package %in% base_pkgs)
+}
+
+cff_dependency_desc_fields <- function(mod, package) {
+  # Get URL and repository from package DESCRIPTION.
+  # URLs from citation() vary due to auto = TRUE.
+  dfile <- system.file("DESCRIPTION", package = package)
+
+  if (file_exist_abort(dfile)) {
+    pkg <- desc::desc(dfile)
+    mod$url <- get_desc_urls(pkg)$url
+    mod$repository <- get_desc_repository(pkg)
+  }
+
+  mod
+}
+
+cff_dependency_year <- function(mod) {
+  date_rel <- mod[["date-released"]]
+
+  if (is.null(date_rel)) {
+    return(format(Sys.Date(), "%Y"))
+  }
+
+  format(as.Date(date_rel), "%Y")
+}
+
+cff_dependency_order <- function(mod) {
+  first_keys <- c("type", "title", "abstract", "notes", "url", "repository")
+  c(mod[first_keys], mod[!names(mod) %in% first_keys])
 }

--- a/R/utils-persons.R
+++ b/R/utils-persons.R
@@ -1,11 +1,5 @@
 bibtex_pers_von_last_first_jr <- function(x) {
-  # Protect commas inside braces to avoid splitting errors.
-  protected <- gsub(",(?![^\\}]*(\\{|$))", "@comma@", x, perl = TRUE)
-
-  parts_comma <- trimws(unlist(strsplit(protected, ",")))
-
-  # Unprotect.
-  parts_comma <- gsub("@comma@", ",", parts_comma, fixed = TRUE)
+  parts_comma <- bibtex_split_protected(x, ",", "@comma@")
 
   if (length(parts_comma) == 3) {
     given <- parts_comma[3]
@@ -20,70 +14,18 @@ bibtex_pers_von_last_first_jr <- function(x) {
   # From here, it is the same as in bibtex_person_von_last_first().
 
   # Identify the von part.
-
-  # Protect spaces inside braces before splitting.
-  protected <- gsub(
-    "\\s(?![^\\}]*(\\{|$))",
-    "@blank@",
-    parts_comma[1],
-    perl = TRUE
-  )
-
-  parts <- unlist(strsplit(protected, " "))
-
-  # Unprotect.
-  parts <- gsub("@blank@", " ", parts, fixed = TRUE)
-
-  # Start building.
-  # Assess casing.
-
-  is_upper <- vapply(parts, FUN.VALUE = logical(1), function(y) {
-    case <- substr(y, 1, 1)
-    if (case == toupper(case)) {
-      TRUE
-    } else {
-      FALSE
-    }
-  })
-
-  # Family should always be provided.
-  family <- parts[length(parts)]
-
-  upper <- is_upper[setdiff(names(is_upper), family)]
-
-  # Get more family parts.
-  invert <- rev(upper)
-  # Then get the family sequentially.
-  for (i in seq_along(invert)) {
-    if (!invert[i]) {
-      break
-    }
-    family <- c(names(invert[i]), family)
-  }
-
-  # The remaining part is von.
-  von <- setdiff(names(is_upper), family)
-
-  if (length(von) == 0) {
-    von <- NULL
-  }
+  family_von <- bibtex_family_von(parts_comma[1])
 
   # Compose the final list to pass to person().
 
   # Final cleanup.
-  end_list <- list(given = given, von = von, family = family, jr = jr)
+  end_list <- c(list(given = given), family_von, list(jr = jr))
 
   end_list
 }
 
 bibtex_pers_von_last_first <- function(x) {
-  # Protect commas inside braces to avoid splitting errors.
-  protected <- gsub(",(?![^\\}]*(\\{|$))", "@comma@", x, perl = TRUE)
-
-  parts_comma <- trimws(unlist(strsplit(protected, ",")))
-
-  # Unprotect.
-  parts_comma <- gsub("@comma@", ",", parts_comma, fixed = TRUE)
+  parts_comma <- bibtex_split_protected(x, ",", "@comma@")
 
   if (length(parts_comma) == 2) {
     given <- parts_comma[2]
@@ -93,58 +35,12 @@ bibtex_pers_von_last_first <- function(x) {
   }
 
   # Identify the von part.
-
-  # Protect spaces inside braces before splitting.
-  protected <- gsub(
-    "\\s(?![^\\}]*(\\{|$))",
-    "@blank@",
-    parts_comma[1],
-    perl = TRUE
-  )
-
-  parts <- unlist(strsplit(protected, " "))
-
-  # Unprotect.
-  parts <- gsub("@blank@", " ", parts, fixed = TRUE)
-
-  # Start building.
-  # Assess casing.
-
-  is_upper <- vapply(parts, FUN.VALUE = logical(1), function(y) {
-    case <- substr(y, 1, 1)
-    if (case == toupper(case)) {
-      TRUE
-    } else {
-      FALSE
-    }
-  })
-
-  # Family should always be provided.
-  family <- parts[length(parts)]
-
-  upper <- is_upper[setdiff(names(is_upper), family)]
-
-  # Get more family parts.
-  invert <- rev(upper)
-  # Then get the family sequentially.
-  for (i in seq_along(invert)) {
-    if (!invert[i]) {
-      break
-    }
-    family <- c(names(invert[i]), family)
-  }
-
-  # The remaining part is von.
-  von <- setdiff(names(is_upper), family)
-
-  if (length(von) == 0) {
-    von <- NULL
-  }
+  family_von <- bibtex_family_von(parts_comma[1])
 
   # Compose the final list to pass to person().
 
   # Final cleanup.
-  end_list <- list(given = given, von = von, family = family)
+  end_list <- c(list(given = given), family_von)
 
   end_list
 }
@@ -163,33 +59,20 @@ bibtex_pers_first_von_last <- function(x) {
   # jean De la Fontaine     -> ""             "jean De la"  "Fontaine"
   # Jean de La Fontaine     -> "Jean"         "de"          "La Fontaine"
 
-  # Protect spaces inside braces before splitting.
-  x <- gsub("\\s(?![^\\}]*(\\{|$))", "@blank@", x, perl = TRUE)
+  parts <- bibtex_split_name_words(x)
 
   # Collapse blanks.
-  x <- gsub("\\s+", " ", x)
-
-  parts <- trimws(unlist(strsplit(x, " ")))
-
-  # Unprotect.
-  parts <- gsub("@blank@", " ", parts, fixed = TRUE)
+  parts <- trimws(parts)
 
   # Start building.
   # Assess casing.
 
-  is_upper <- vapply(parts, FUN.VALUE = logical(1), function(y) {
-    case <- substr(y, 1, 1)
-    if (case == toupper(case)) {
-      TRUE
-    } else {
-      FALSE
-    }
-  })
+  is_upper <- bibtex_is_upper(parts)
 
   # Family should always be provided.
   family <- parts[length(parts)]
 
-  # Check if there is a mix of casings in the remaining parts.
+  # Check whether the remaining parts mix casing styles.
   upper <- is_upper[setdiff(names(is_upper), family)]
   mix <- (length(unique(upper)) == 1)
 
@@ -228,6 +111,76 @@ bibtex_pers_first_von_last <- function(x) {
   end_list <- list(given = given, von = von, family = family)
 
   end_list
+}
+
+bibtex_family_von <- function(x) {
+  parts <- bibtex_split_name_words(x)
+  is_upper <- bibtex_is_upper(parts)
+
+  # Family should always be provided.
+  family <- parts[length(parts)]
+
+  upper <- is_upper[setdiff(names(is_upper), family)]
+
+  # Get more family parts.
+  family <- bibtex_extend_family(family, upper)
+
+  # The remaining part is von.
+  von <- setdiff(names(is_upper), family)
+
+  if (length(von) == 0) {
+    von <- NULL
+  }
+
+  list(von = von, family = family)
+}
+
+bibtex_split_protected <- function(x, pattern, placeholder) {
+  protected <- gsub(
+    paste0(pattern, "(?![^\\}]*(\\{|$))"),
+    placeholder,
+    x,
+    perl = TRUE
+  )
+  parts <- trimws(unlist(strsplit(protected, pattern)))
+  gsub(placeholder, pattern, parts, fixed = TRUE)
+}
+
+bibtex_split_name_words <- function(x) {
+  # Protect spaces inside braces before splitting.
+  protected <- gsub("\\s(?![^\\}]*(\\{|$))", "@blank@", x, perl = TRUE)
+
+  # Collapse blanks.
+  protected <- gsub("\\s+", " ", protected)
+
+  parts <- unlist(strsplit(protected, " "))
+
+  # Unprotect.
+  gsub("@blank@", " ", parts, fixed = TRUE)
+}
+
+bibtex_is_upper <- function(parts) {
+  vapply(parts, FUN.VALUE = logical(1), function(y) {
+    case <- substr(y, 1, 1)
+    if (case == toupper(case)) {
+      TRUE
+    } else {
+      FALSE
+    }
+  })
+}
+
+bibtex_extend_family <- function(family, upper) {
+  invert <- rev(upper)
+  # Then get the family sequentially.
+  for (i in seq_along(invert)) {
+    if (!invert[i]) {
+      break
+    }
+    family <- c(names(invert[i]), family)
+  }
+
+  family
 }
 
 validate_cff_person_fields <- function(person_cff) {
@@ -327,35 +280,7 @@ extract_person_comments <- function(person) {
     comm_cff$website <- clean_str(web)
   }
 
-  # Add URL to ORCID if not present.
-  # Get leading invalid URLs.
-
-  if (!is.null(comm_cff$orcid)) {
-    orcid <- gsub("^orcid.org/", "", comm_cff$orcid)
-    orcid <- gsub("^https://orcid.org/", "", orcid)
-    orcid <- gsub("^http://orcid.org/", "", orcid)
-
-    comm_cff$orcid <- paste0("https://orcid.org/", orcid)
-  }
-
-  # Add website.
-  web <- comm_cff$website
-
-  if (!is.null(web)) {
-    comm_cff$website <- clean_str(web[is_url(web)])
-  }
-
-  # Also add email.
-  # Check if there are several emails (MomTrunc 6.0).
-  look_emails <- c(unlist(person$email), comm_cff$email)
-  valid_emails <- unlist(lapply(look_emails, is_email))
-  email <- look_emails[valid_emails][1]
-
-  # Final list.
-  fin_list <- c(list(email = NULL), comm_cff["email" != names(comm_cff)])
-  fin_list$email <- clean_str(email)
-
-  fin_list
+  finalize_person_comments(person, comm_cff)
   # nocov end
 }
 
@@ -405,35 +330,37 @@ extract_person_comments45 <- function(person) {
   nms_com <- names(comm_cff)
   comm_cff <- comm_cff[nchar(nms_com) > 1]
 
-  if (!is.null(comm_cff$orcid)) {
-    orcid <- gsub("^orcid.org/", "", comm_cff$orcid)
-    orcid <- gsub("^https://orcid.org/", "", orcid)
-    orcid <- gsub("^http://orcid.org/", "", orcid)
+  finalize_person_comments(p, comm_cff, fallback_ror = TRUE)
+}
 
-    comm_cff$orcid <- paste0("https://orcid.org/", orcid)
+finalize_person_comments <- function(person, comm_cff, fallback_ror = FALSE) {
+  if (!is.null(comm_cff$orcid)) {
+    comm_cff$orcid <- normalize_orcid(comm_cff$orcid)
   }
 
-  # Add website.
   web <- comm_cff$website
-
   if (!is.null(web)) {
     comm_cff$website <- clean_str(web[is_url(web)])
   }
 
-  # Fallback: ROR if website is not present.
   ror <- comm_cff$ror
-  if (all(!is.null(ror), is.null(comm_cff$website))) {
+  if (all(fallback_ror, !is.null(ror), is.null(comm_cff$website))) {
     comm_cff$website <- clean_str(ror[is_url(ror)])
   }
 
-  # Also add email.
-  # Check if there are several emails (MomTrunc 6.0).
-  look_emails <- c(unlist(p$email), comm_cff$email)
+  # Check whether there are several emails (MomTrunc 6.0).
+  look_emails <- c(unlist(person$email), comm_cff$email)
   valid_emails <- unlist(lapply(look_emails, is_email))
   email <- look_emails[valid_emails][1]
 
-  # Final list.
   fin_list <- c(list(email = NULL), comm_cff["email" != names(comm_cff)])
   fin_list$email <- clean_str(email)
   fin_list
+}
+
+normalize_orcid <- function(orcid) {
+  orcid <- gsub("^orcid.org/", "", orcid)
+  orcid <- gsub("^https://orcid.org/", "", orcid)
+  orcid <- gsub("^http://orcid.org/", "", orcid)
+  paste0("https://orcid.org/", orcid)
 }

--- a/R/utils-schema.R
+++ b/R/utils-schema.R
@@ -1,6 +1,5 @@
 #' Schema utils
 #'
-#' @name cff_schema
 #' @description
 #' Helper functions with the valid values of different fields, according to the
 #' ```{r, echo=FALSE, results='asis'}
@@ -22,6 +21,13 @@
 #' - [cff_schema_definitions_refs()] provides the valid
 #'   keys to be used on the `preferred-citation` and `references` keys.
 #'
+#' @param sorted Logical `TRUE/FALSE`. Should the keys be arranged
+#'   alphabetically?
+#'
+#' @return
+#' A character vector with the names of valid keys for Citation File Format
+#' version 1.2.0.
+#'
 #' @source
 #' ```{r, echo=FALSE, results='asis'}
 #'
@@ -32,23 +38,14 @@
 #' ```
 #'
 #' @family schemas
-#'
 #' @export
 #' @encoding UTF-8
-#'
-#' @return
-#' A character vector with the names of valid keys for Citation File Format
-#'   version 1.2.0.
-#'
-#' @param sorted Logical `TRUE/FALSE`. Should the keys be arranged
-#'   alphabetically?
-#'
+#' @name cff_schema
 #' @examples
-#'
 #' cff_schema_keys(sorted = TRUE)
 cff_schema_keys <- function(sorted = FALSE) {
   if (sorted) {
-    # Alphabetically
+    # Sort alphabetically.
     schema_keys <- c(
       "abstract",
       "authors",
@@ -73,7 +70,7 @@ cff_schema_keys <- function(sorted = FALSE) {
       "version"
     )
   } else {
-    # Arranged arbitrarily
+    # Keep the preferred schema order.
     schema_keys <- c(
       "cff-version",
       "message",
@@ -102,11 +99,10 @@ cff_schema_keys <- function(sorted = FALSE) {
   schema_keys
 }
 
-#' @rdname cff_schema
 #' @export
 #' @encoding UTF-8
+#' @rdname cff_schema
 #' @examples
-#'
 #' # Valid license keys.
 #' head(cff_schema_keys_license(), 20)
 cff_schema_keys_license <- function() {
@@ -119,11 +115,10 @@ cff_schema_keys_license <- function() {
   license
 }
 
-#' @rdname cff_schema
 #' @export
 #' @encoding UTF-8
+#' @rdname cff_schema
 #' @examples
-#'
 #' cff_schema_definitions_person()
 cff_schema_definitions_person <- function() {
   definitions_person <- c(
@@ -148,11 +143,10 @@ cff_schema_definitions_person <- function() {
   definitions_person
 }
 
-#' @rdname cff_schema
 #' @export
 #' @encoding UTF-8
+#' @rdname cff_schema
 #' @examples
-#'
 #' cff_schema_definitions_entity()
 cff_schema_definitions_entity <- function() {
   definitions_entity <- c(
@@ -175,11 +169,10 @@ cff_schema_definitions_entity <- function() {
   definitions_entity
 }
 
-#' @rdname cff_schema
 #' @export
 #' @encoding UTF-8
+#' @rdname cff_schema
 #' @examples
-#'
 #' cff_schema_definitions_refs()
 cff_schema_definitions_refs <- function() {
   definitions_reference <- c(

--- a/R/utils.R
+++ b/R/utils.R
@@ -151,7 +151,7 @@ fuzzy_keys <- function(keys) {
     bullets <- rep("v", length(ll))
     bullets[keys_match == "No match, removing."] <- "x"
     names(ll) <- bullets
-    cli::cli_alert_info(paste0("Found misspelled keys. Trying to map:"))
+    cli::cli_alert_info("Found misspelled keys. Trying to map them:")
 
     cli::cli_bullets(ll)
     # Modify names.
@@ -174,7 +174,7 @@ guess_cff_named_part <- function(x) {
     return("cff_pers")
   }
 
-  # Valid full CFF file.
+  # Valid full `CITATION.cff` file.
   is_full <- any(grepl("cff-version|message", nms))
   if (is_full) {
     return("cff_full")

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,6 +51,12 @@ print_snapshot <- function(title = "----", obj) {
   cat("\n---")
 }
 
+# nocov start
+get_avail_on_init <- function() {
+  avail_on_init
+}
+# nocov end
+
 #' Search for a package in available repositories.
 #' @param name Name of the package.
 #' @param avail Data frame with available packages. See
@@ -59,7 +65,7 @@ print_snapshot <- function(title = "----", obj) {
 #' @noRd
 search_on_repos <- function(
   name,
-  avail = avail_on_init,
+  avail = get_avail_on_init(),
   repos = detect_repos()
 ) {
   get <- avail[name == avail$Package, "Repository"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ their repositories to let others know how to correctly cite their
 software.
 
 This format is gaining popularity within the software citation
-ecosystem. Recently,
+ecosystem.
 [GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files),
 [Zenodo](https://citation-file-format.github.io/#/supported-by-zenodo-)
 and
@@ -79,7 +79,7 @@ and the `CITATION` file (if present) from your package. Note that
 **cffr** works best if your package passes
 `R CMD check/devtools::check()`.
 
-As per 2026-05-26 there are at least 559 repositories on GitHub using
+As per 2026-06-02 there are at least 546 repositories on GitHub using
 **cffr**. [Check them out
 here](https://github.com/search?q=cffr%20path%3A**%2FCITATION.cff&type=code).
 
@@ -122,8 +122,8 @@ cff_write()
 #>
 #> CITATION.cff generated.
 #>
-#> cff_validate results-----
-#> Congratulations! This .cff file is valid.
+#> ══ Validating cff ══════════════════════════════════════════════════════════════
+#> This .cff file is valid.
 ```
 
 However, **cffr** also provides custom print methods and mechanisms that
@@ -441,6 +441,37 @@ test <- cff_create("knitr")
       year: '2026'
       doi: 10.32614/CRAN.package.magick
     - type: software
+      title: litedown
+      abstract: 'litedown: A Lightweight Version of R Markdown'
+      notes: Suggests
+      url: https://github.com/yihui/litedown
+      repository: https://CRAN.R-project.org/package=litedown
+      authors:
+      - family-names: Xie
+        given-names: Yihui
+        email: xie@yihui.name
+        orcid: https://orcid.org/0000-0003-0645-5666
+      year: '2026'
+      doi: 10.32614/CRAN.package.litedown
+    - type: software
+      title: markdown
+      abstract: 'markdown: Render Markdown with ''commonmark'''
+      notes: Suggests
+      url: https://github.com/rstudio/markdown
+      repository: https://CRAN.R-project.org/package=markdown
+      authors:
+      - family-names: Xie
+        given-names: Yihui
+        email: xie@yihui.name
+        orcid: https://orcid.org/0000-0003-0645-5666
+      - family-names: Allaire
+        given-names: JJ
+      - family-names: Horner
+        given-names: Jeffrey
+      year: '2026'
+      doi: 10.32614/CRAN.package.markdown
+      version: '>= 1.3'
+    - type: software
       title: otel
       abstract: 'otel: OpenTelemetry R API'
       notes: Suggests
@@ -661,17 +692,18 @@ cff_validate(test)
 #> ══ Validating cff ══════════════════════════════════════════════════════════════
 ```
 
-See the [docs](https://docs.ropensci.org/cffr/reference/index.html) and
-`vignette("cffr", package = "cffr")` for more on working with `cff`
-objects.
+See the [reference
+documentation](https://docs.ropensci.org/cffr/reference/index.html) and
+`vignette("cffr", package = "cffr")` to learn more about working with
+`cff` objects.
 
 ### Keep your `CITATION.cff` file up to date
 
 #### GitHub Actions
 
 The easiest way to keep your `CITATION.cff` file up to date is to use
-GitHub Actions. Use the `cff_gha_update()` function to install a GitHub
-Action that will update your `CITATION.cff` file in the following cases:
+**GitHub Actions**. Use `cff_gha_update()` to install a GitHub Action
+that updates your `CITATION.cff` file in the following cases:
 
 - When you publish a new release of the package on your GitHub
   repository.
@@ -709,7 +741,7 @@ make sure you have the **testthat** package installed.
 Check the following articles to learn more about **cffr**:
 
 - [cffr: Create a CITATION.cff file for your R
-  Package](https://ropensci.org/blog/2021/11/23/cffr/) ([Hernangómez
+  package](https://ropensci.org/blog/2021/11/23/cffr/) ([Hernangómez
   2021a](#ref-hernangomez_cffr_2021))
 - [How I test cffr on about 2,000 packages using GitHub Actions and
   R-universe](https://ropensci.org/blog/2021/11/23/how-i-test-cffr/)
@@ -721,7 +753,7 @@ Check the following articles to learn more about **cffr**:
   function `r2cff` that creates a `CITATION.cff` file (v1.1.0) using the
   information in your `DESCRIPTION` file. It also provides minimal
   validity checks.
-- **handlr** ([Chamberlain and Wiernik 2025](#ref-handlr)): Tool for
+- **handlr** ([Chamberlain and Wiernik 2025](#ref-handlr)) is a tool for
   converting among citation formats, including `*.cff` files.
 - **codemeta** ([Boettiger and Salmon 2021](#ref-codemeta)) /
   **codemetar** ([Boettiger and Salmon 2026](#ref-codemetar2021))

--- a/README.qmd
+++ b/README.qmd
@@ -51,7 +51,6 @@ developers can include them in their repositories to let others know how to
 correctly cite their software.
 
 This format is gaining popularity within the software citation ecosystem.
-Recently,
 [GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files),
 [Zenodo](https://citation-file-format.github.io/#/supported-by-zenodo-) and
 [Zotero](https://citation-file-format.github.io/#/supported-by-zotero-) have
@@ -175,8 +174,8 @@ install.packages(
 ### Example
 
 Most commonly, from within your package folder, you run `cff_write()`. It
-creates a `cff` object, writes it to a `CITATION.cff` file and validates it in
-a single command:
+creates a `cff` object, writes it to a `CITATION.cff` file and validates it in a
+single command:
 
 ```{r}
 #| eval: false
@@ -187,8 +186,8 @@ cff_write()
 #>
 #> CITATION.cff generated.
 #>
-#> cff_validate results-----
-#> Congratulations! This .cff file is valid.
+#> ══ Validating cff ══════════════════════════════════════════════════════════════
+#> This .cff file is valid.
 ```
 
 However, **cffr** also provides custom print methods and mechanisms that allow
@@ -223,16 +222,18 @@ We can validate the result using `cff_validate()`:
 cff_validate(test)
 ```
 
-See the [docs](https://docs.ropensci.org/cffr/reference/index.html) and
-`vignette("cffr", package = "cffr")` for more on working with `cff` objects.
+See the [reference
+documentation](https://docs.ropensci.org/cffr/reference/index.html) and
+`vignette("cffr", package = "cffr")` to learn more about working with `cff`
+objects.
 
 ### Keep your `CITATION.cff` file up to date
 
 #### GitHub Actions
 
-The easiest way to keep your `CITATION.cff` file up to date is to use GitHub
-Actions. Use the `cff_gha_update()` function to install a GitHub Action that
-will update your `CITATION.cff` file in the following cases:
+The easiest way to keep your `CITATION.cff` file up to date is to use **GitHub
+Actions**. Use `cff_gha_update()` to install a GitHub Action that updates your
+`CITATION.cff` file in the following cases:
 
 - When you publish a new release of the package on your GitHub repository.
 - Each time you modify your `DESCRIPTION` or `inst/CITATION` files.
@@ -256,8 +257,8 @@ hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_committing_workf
 
 > The `pre-commit` hook is run first, before you even type in a commit message.
 > It is used to inspect the snapshot that is about to be committed, to see if
-> you have forgotten something, to make sure tests run or to examine whatever you
-> need to inspect in the code. Exiting non-zero from this hook aborts the
+> you have forgotten something, to make sure tests run or to examine whatever
+> you need to inspect in the code. Exiting non-zero from this hook aborts the
 > commit, although you can bypass it with `git commit --no-verify`.
 
 A specific pre-commit hook can be installed with `cff_git_hook_install()`. If
@@ -269,7 +270,7 @@ package installed.
 Check the following articles to learn more about **cffr**:
 
 - [cffr: Create a CITATION.cff file for your R
-  Package](https://ropensci.org/blog/2021/11/23/cffr/) [@hernangomez_cffr_2021]
+  package](https://ropensci.org/blog/2021/11/23/cffr/) [@hernangomez_cffr_2021]
 - [How I test cffr on about 2,000 packages using GitHub Actions and
   R-universe](https://ropensci.org/blog/2021/11/23/how-i-test-cffr/)
   [@hernangomez_test_2021]
@@ -279,8 +280,8 @@ Check the following articles to learn more about **cffr**:
 - **citation** [@citation22] includes a function `r2cff` that creates a
   `CITATION.cff` file (v1.1.0) using the information in your `DESCRIPTION` file.
   It also provides minimal validity checks.
-- **handlr** [@handlr]: Tool for converting among citation formats, including
-  `*.cff` files.
+- **handlr** [@handlr] is a tool for converting among citation formats,
+  including `*.cff` files.
 - **codemeta** [@codemeta] / **codemetar** [@codemetar2021] provide similar
   solutions for creating `codemeta.json` files, another format for storing and
   sharing software metadata.

--- a/codemeta.json
+++ b/codemeta.json
@@ -2,13 +2,13 @@
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
   "@type": "SoftwareSourceCode",
   "identifier": "cffr",
-  "description": "Citation File Format ('CFF') version 1.2.0 <doi:10.5281/zenodo.5171937> is a human- and machine-readable file format for software citation metadata. The package provides core utilities to generate and validate this metadata for R packages.",
+  "description": "Citation File Format ('CFF') version 1.2.0 <doi:10.5281/zenodo.5171937> is a human- and machine-readable file format for software citation metadata. The package provides core utilities to generate, read, write and validate this metadata for R packages.",
   "name": "cffr: Generate Citation File Format ('CFF') Metadata for R Packages",
   "relatedLink": ["https://docs.ropensci.org/cffr/", "https://CRAN.R-project.org/package=cffr"],
   "codeRepository": "https://github.com/ropensci/cffr",
   "issueTracker": "https://github.com/ropensci/cffr/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "1.4.0",
+  "version": "1.4.0.9000",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -222,7 +222,7 @@
   },
   "isPartOf": "https://ropensci.org",
   "keywords": ["attribution", "citation", "credit", "citation-files", "cff", "metadata", "citation-file-format", "cran", "r", "r-package", "ropensci", "rstats", "r-cran"],
-  "fileSize": "993.133KB",
+  "fileSize": "992.392KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",

--- a/codemeta.json
+++ b/codemeta.json
@@ -222,7 +222,7 @@
   },
   "isPartOf": "https://ropensci.org",
   "keywords": ["attribution", "citation", "credit", "citation-files", "cff", "metadata", "citation-file-format", "cran", "r", "r-package", "ropensci", "rstats", "r-cran"],
-  "fileSize": "992.392KB",
+  "fileSize": "992.648KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",

--- a/inst/schemaorg.json
+++ b/inst/schemaorg.json
@@ -12,7 +12,7 @@
     "familyName": "Hernangómez",
     "givenName": "Diego"
   },
-  "description": "Citation File Format ('CFF') version 1.2.0 <doi:10.5281/zenodo.5171937> is a human- and machine-readable file format for software citation metadata. The package provides core utilities to generate and validate this metadata for R packages.",
+  "description": "Citation File Format ('CFF') version 1.2.0 <doi:10.5281/zenodo.5171937> is a human- and machine-readable file format for software citation metadata. The package provides core utilities to generate, read, write and validate this metadata for R packages.",
   "license": "https://spdx.org/licenses/GPL-3.0",
   "name": "cffr: Generate Citation File Format ('CFF') Metadata for R Packages",
   "programmingLanguage": {
@@ -27,5 +27,5 @@
     "url": "https://cran.r-project.org"
   },
   "runtimePlatform": "R version 4.6.0 (2026-04-24 ucrt)",
-  "version": "1.4.0"
+  "version": "1.4.0.9000"
 }

--- a/man/as_bibentry.Rd
+++ b/man/as_bibentry.Rd
@@ -36,9 +36,9 @@ as_bibentry(x, ...)
 in-development package.
 \item An existing \code{cff} object created with \code{\link[=cff]{cff()}}, \code{\link[=cff_create]{cff_create()}}, or
 \code{\link[=as_cff]{as_cff()}}.
-\item Path to a CITATION.cff file (\code{"CITATION.cff"}).
+\item Path to a \code{CITATION.cff} file (\code{"CITATION.cff"}).
 \item The name of an installed package (\code{"jsonlite"}).
-\item Path to a DESCRIPTION file (\code{"DESCRIPTION"}).
+\item Path to a \code{DESCRIPTION} file (\code{"DESCRIPTION"}).
 }}
 
 \item{...}{Additional arguments to be passed to or from methods.}
@@ -71,7 +71,7 @@ objects can be converted to BibTeX markup with \code{\link[=toBibtex]{toBibtex()
 an object of class \code{Bibtex} that can be printed and exported as a valid
 BibTeX entry.
 
-\code{as_bibtex()} tries to map the information of the source \code{x} into a \code{\link{cff}}
+\code{as_bibentry()} tries to map the information of the source \code{x} into a \code{\link{cff}}
 object and performs a mapping of the metadata to BibTeX, according to
 \code{vignette("bibtex-cff", package = "cffr")}.
 }
@@ -82,7 +82,7 @@ cff_object <- cff()
 
 cff_object
 
-# bibentry object.
+# A bibentry object.
 bib <- as_bibentry(cff_object)
 
 class(bib)
@@ -135,7 +135,7 @@ toBibtex(desc_file)
 metadata of a package is mapped to produce a \code{cff} object.
 \item \code{vignette("bibtex-cff", package = "cffr")} provides detailed information
 about the internal mapping performed between \code{cff} objects and BibTeX
-markup (both \code{cff} to BibTeX and BibTeX to \code{cff}).
+markup, both \code{cff} to BibTeX and BibTeX to \code{cff}.
 }
 
 Other related functions:
@@ -143,13 +143,13 @@ Other related functions:
 \item \code{\link[utils:toBibtex]{utils::toBibtex()}}.
 }
 
-Other functions for working with BibTeX format:
+Work with BibTeX metadata:
 \code{\link[=cff_read]{cff_read()}},
 \code{\link[=cff_read_bib_text]{cff_read_bib_text()}},
 \code{\link[=cff_write_bib]{cff_write_bib()}},
 \code{\link[=encoded_utf_to_latex]{encoded_utf_to_latex()}}
 
-Coercing between \strong{R} classes with \strong{S3 Methods}:
+Coerce between \R classes:
 \code{\link[=as_cff]{as_cff()}},
 \code{\link[=as_cff_person]{as_cff_person()}},
 \code{\link{cff_class}}

--- a/man/as_cff.Rd
+++ b/man/as_cff.Rd
@@ -44,9 +44,9 @@ corresponding subclass.
 Learn more about the \CRANpkg{cffr} class system in \link{cff_class}.
 }
 \description{
-\code{as_cff()} turns an existing list-like \R object into a so-called
-\code{\link{cff}}, a list with class \code{cff}, with the corresponding
-\link[=cff_class]{sub-class} if applicable.
+\code{as_cff()} turns an existing list-like \R object into a \code{\link{cff}} object,
+a list with class \code{cff} and the corresponding \link[=cff_class]{subclass} when
+applicable.
 
 \code{as_cff} is an S3 generic, with methods for:
 \itemize{
@@ -66,7 +66,6 @@ performed.
 functions are similar.
 }
 \examples{
-
 # Convert a list to a `cff` object.
 cffobj <- as_cff(list(
   "cff-version" = "1.2.0",
@@ -99,12 +98,12 @@ as_cff(a_cit)
 \item \code{\link[=cff_modify]{cff_modify()}}: Modify a \code{cff} object.
 \item \code{\link[=cff_create]{cff_create()}}: Create a \code{cff} object for an \R package.
 \item \code{\link[=cff_read]{cff_read()}}: Create a \code{cff} object from an external file.
-\item \code{\link[=as_cff_person]{as_cff_person()}}: Recommended way to create persons in CFF format.
+\item \code{\link[=as_cff_person]{as_cff_person()}}: Recommended way to create CFF person metadata.
 }
 
 Learn more about the \CRANpkg{cffr} class system in \link{cff_class}.
 
-Coercing between \strong{R} classes with \strong{S3 Methods}:
+Coerce between \R classes:
 \code{\link[=as_bibentry]{as_bibentry()}},
 \code{\link[=as_cff_person]{as_cff_person()}},
 \code{\link{cff_class}}

--- a/man/as_cff_person.Rd
+++ b/man/as_cff_person.Rd
@@ -69,13 +69,13 @@ Mapping is performed as follows:
 For entities, the entire \code{character} is mapped to \code{name}.
 It is recommended to "protect" entity names with \code{{}}:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Don't do
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Do not use unprotected entity names.
 entity <- "Elephant and Castle"
 as_cff_person(entity)
 - name: Elephant
 - name: Castle
 
-# Do
+# Protect entity names with braces.
 entity_protect <- "\{Elephant and Castle\}"
 as_cff_person(entity_protect)
 - name: Elephant and Castle
@@ -159,10 +159,9 @@ See \strong{Examples} for more information.
 }
 \seealso{
 Examples in \code{vignette("cffr", package = "cffr")} and \code{\link[utils:person]{utils::person()}}.
-
 Learn more about the \code{cff_pers_lst} and \code{cff_pers} classes in \link{cff_class}.
 
-Coercing between \strong{R} classes with \strong{S3 Methods}:
+Coerce between \R classes:
 \code{\link[=as_bibentry]{as_bibentry()}},
 \code{\link[=as_cff]{as_cff()}},
 \code{\link{cff_class}}

--- a/man/cff.Rd
+++ b/man/cff.Rd
@@ -80,7 +80,7 @@ cff_validate(new)
 
 }
 \seealso{
-Other core functions of \CRANpkg{cffr}:
+Core \CRANpkg{cffr} workflow:
 \code{\link[=cff_create]{cff_create()}},
 \code{\link[=cff_modify]{cff_modify()}},
 \code{\link[=cff_validate]{cff_validate()}}

--- a/man/cff_class.Rd
+++ b/man/cff_class.Rd
@@ -113,7 +113,7 @@ class(two_persons[[1]])
 
 # Array of references.
 
-cit <- c(citation(), citation("yaml"))
+cit <- c(citation(), citation("jsonlite"))
 
 ref_list <- as_cff(cit)
 
@@ -130,17 +130,15 @@ ref_list
 #>   year: '2026'
 #>   doi: 10.32614/R.manuals
 #>   url: https://www.R-project.org/
-#> - type: manual
-#>   title: 'yaml: Methods to Convert R Data to YAML and Back'
+#> - type: article
+#>   title: 'The jsonlite Package: A Practical and Consistent Mapping Between JSON Data
+#>     and R Objects'
 #>   authors:
-#>   - family-names: Stephens
-#>     given-names: Jeremy
-#>   - family-names: Simonov
-#>     given-names: Kirill
-#>   year: '2025'
-#>   notes: R package version 2.3.12
-#>   url: https://CRAN.R-project.org/package=yaml
-#>   doi: 10.32614/CRAN.package.yaml
+#>   - family-names: Ooms
+#>     given-names: Jeroen
+#>   journal: arXiv:1403.2805 [stat.CO]
+#>   year: '2014'
+#>   url: https://arxiv.org/abs/1403.2805
 
 class(ref_list)
 #> [1] "cff_ref_lst" "cff"
@@ -317,13 +315,12 @@ toBibtex(cit)
 #>   url = \{https://www.R-project.org/\},
 #> \}
 #> 
-#> @Manual\{,
-#>   title = \{yaml: Methods to Convert R Data to YAML and Back\},
-#>   author = \{Jeremy Stephens and Kirill Simonov\},
-#>   year = \{2025\},
-#>   note = \{R package version 2.3.12\},
-#>   url = \{https://CRAN.R-project.org/package=yaml\},
-#>   doi = \{10.32614/CRAN.package.yaml\},
+#> @Article\{,
+#>   title = \{The jsonlite Package: A Practical and Consistent Mapping Between JSON Data and R Objects\},
+#>   author = \{Jeroen Ooms\},
+#>   journal = \{arXiv:1403.2805 [stat.CO]\},
+#>   year = \{2014\},
+#>   url = \{https://arxiv.org/abs/1403.2805\},
 #> \}
 
 # For `cff_pers` and `cff_pers_lst`.

--- a/man/cff_class.Rd
+++ b/man/cff_class.Rd
@@ -31,9 +31,8 @@
 \alias{as.person.cff_ref_lst}
 \title{The \code{cff} class}
 \description{
-\href{https://cran.r-project.org/package=cffr}{\strong{cffr}} implements an S3 object with
-\code{\link{class}} \code{cff}, which is used to represent the information of a \code{CITATION.cff}
-file in \strong{R}.
+\CRANpkg{cffr} implements an S3 object with \code{\link{class}} \code{cff}, which represents
+the information in a \code{CITATION.cff} file in \R.
 
 Under the hood, a \code{cff} object is simply a named \code{\link{list}} to which we added
 additional methods, most notably \code{\link{print}} and \code{\link[=as_cff]{as_cff()}}.
@@ -43,7 +42,7 @@ additional methods, most notably \code{\link{print}} and \code{\link[=as_cff]{as
   fifth = "with", sixth = "names", "none" = NULL
 )
 
-# As cff
+# Convert to `cff`.
 a_cff_object <- as_cff(a_named_list)
 
 class(a_cff_object)
@@ -61,30 +60,30 @@ is.list(a_cff_object)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 
-\code{\link[=as_cff]{as_cff()}} not only converts a \code{list} to \code{cff} but also removes items (known as
-\code{keys} in CFF terminology) that are \code{NULL} or \code{NA}.
-\subsection{Sub-classes}{
+\code{\link[=as_cff]{as_cff()}} not only converts a \code{list} to \code{cff} but also removes items that are
+\code{NULL} or \code{NA}. These items are known as \code{keys} in CFF terminology.
+\subsection{Subclasses}{
 
-\strong{cffr} implements two special sub-classes of \code{cff}, with the aim of
-representing two special types of objects defined in the \href{https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md}{CFF Schema}:
+\strong{cffr} implements two special subclasses of \code{cff}, which represent two special
+types of objects defined in the \href{https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md}{Citation File Format schema}:
 \itemize{
-\item \code{definition.person} and \code{definition.entity}: CFF definitions for sub-lists
-representing persons or entities. In \strong{cffr}, the sub-class \code{cff_pers_lst}
-has been implemented to collect an array of \code{definition.person/entity},
-where each individual person or entity has a sub-class \code{cff_pers}.
-\item Similarly, \code{definition.reference} is the CFF definition for collecting
-references to related works and other articles of software used in the
-development of the main work of the CFF file. This is implemented in
-\strong{cffr} as a sub-class named \code{cff_ref_lst} for arrays of
-\code{definition.reference}, where each element has a sub-class named \code{cff_ref}.
+\item \code{definitions.person} and \code{definitions.entity}: CFF definitions for sublists
+representing persons or entities. In \strong{cffr}, the subclass \code{cff_pers_lst}
+collects an array of \code{definitions.person} or \code{definitions.entity} objects,
+where each individual person or entity has subclass \code{cff_pers}.
+\item Similarly, \code{definitions.reference} is the CFF definition for collecting
+references to related works and other software used in the development of the
+main work of the \code{CITATION.cff} file. In \strong{cffr}, the subclass \code{cff_ref_lst}
+represents arrays of \code{definitions.reference} objects, where each element has
+subclass \code{cff_ref}.
 }
 
-These two sub-classes do not provide full valid \code{cff} objects, but adapt
+These two subclasses do not provide full valid \code{cff} objects, but adapt
 information to the schema required by CFF:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Using the utils::person() function
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Use the utils::person() function.
 
-## Array
+## Array.
 two_persons <- as_cff_person(
   c(
     person("A", "person", comment = c(ORCID = "0000-0001-8457-4658")),
@@ -102,7 +101,7 @@ two_persons
 class(two_persons)
 #> [1] "cff_pers_lst" "cff"
 
-# Single element
+# Single element.
 
 two_persons[[1]]
 #> family-names: person
@@ -112,7 +111,7 @@ two_persons[[1]]
 class(two_persons[[1]])
 #> [1] "cff_pers" "cff"
 
-# Array of references
+# Array of references.
 
 cit <- c(citation(), citation("yaml"))
 
@@ -146,7 +145,7 @@ ref_list
 class(ref_list)
 #> [1] "cff_ref_lst" "cff"
 
-# Single element
+# Single element.
 
 ref_list[[1]]
 #> type: manual
@@ -169,14 +168,14 @@ class(ref_list[[1]])
 
 \subsection{Valid \code{cff} objects}{
 
-Creating a \code{cff} object does not ensure its validity according to the \href{https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md}{CFF Schema}:
+Creating a \code{cff} object does not ensure its validity according to the \href{https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md}{Citation File Format schema}:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{class(a_cff_object)
 #> [1] "cff"
 
 cff_validate(a_cff_object)
 #> == Validating cff ==============================================================
-#> x Oops! This <cff> has the following errors:
+#> x Validation failed. This <cff> has the following errors:
 #> * cff/: must have required property 'authors'
 #> * cff/: must have required property 'cff-version'
 #> * cff/: must have required property 'message'
@@ -189,8 +188,8 @@ cff_validate(a_cff_object)
 #> * cff/: must NOT have additional properties
 }\if{html}{\out{</div>}}
 
-\code{\link[=cff_validate]{cff_validate()}} gives minimal messages about what's wrong with our \code{cff} and
-(invisibly) returns the result of the validation (\code{TRUE/FALSE}).
+\code{\link[=cff_validate]{cff_validate()}} gives minimal messages about what is wrong with the \code{cff}
+object and invisibly returns the result of the validation (\code{TRUE/FALSE}).
 
 We can use \code{\link[=cff_modify]{cff_modify()}} to add more keys:
 
@@ -202,7 +201,7 @@ We can use \code{\link[=cff_modify]{cff_modify()}} to add more keys:
 )
 
 
-# Remove invalid keys
+# Remove invalid keys.
 cff_valid <- as_cff(cff_valid[names(cff_valid) \%in\% cff_schema_keys()])
 
 cff_valid
@@ -214,7 +213,7 @@ cff_valid
 
 cff_validate(cff_valid)
 #> == Validating cff ==============================================================
-#> v Congratulations! This <cff> is valid.
+#> v This <cff> is valid.
 }\if{html}{\out{</div>}}
 }
 
@@ -299,14 +298,14 @@ Only for \code{cff_pers_lst} and \code{cff_pers} objects:
 
 \subsection{\code{\link[=toBibtex]{toBibtex()}}}{
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{# For cff
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# For `cff`.
 toBibtex(minimal_cff)
 #> @Misc\{doe,
 #>   title = \{My Research Software\},
 #>   author = \{John Doe\},
 #> \}
 
-# cff_ref, cff_ref_lst
+# For `cff_ref` and `cff_ref_lst`.
 toBibtex(cit)
 #> @Manual\{,
 #>   title = \{R: A Language and Environment for Statistical Computing\},
@@ -327,7 +326,7 @@ toBibtex(cit)
 #>   doi = \{10.32614/CRAN.package.yaml\},
 #> \}
 
-# cff_pers, cff_pers_lst
+# For `cff_pers` and `cff_pers_lst`.
 toBibtex(two_persons)
 #> person, A and \{An entity\}
 }\if{html}{\out{</div>}}
@@ -343,7 +342,7 @@ Chapman and Hall/CRC. \doi{10.1201/9781351201315},
 }
 }
 \seealso{
-Coercing between \strong{R} classes with \strong{S3 Methods}:
+Coerce between \R classes:
 \code{\link[=as_bibentry]{as_bibentry()}},
 \code{\link[=as_cff]{as_cff()}},
 \code{\link[=as_cff_person]{as_cff_person()}}

--- a/man/cff_create.Rd
+++ b/man/cff_create.Rd
@@ -32,7 +32,7 @@ in-development \R package.
 \code{CITATION.cff} file adheres to for providing the citation metadata.}
 
 \item{gh_keywords}{Logical \code{TRUE/FALSE}. If the package is hosted on
-GitHub, would you like to add the repository topics as keywords?}
+GitHub, should the repository topics be added as keywords?}
 
 \item{dependencies}{Logical \code{TRUE/FALSE}. Should the dependencies of your
 package be added to the \code{references} CFF key?}
@@ -45,28 +45,27 @@ A \code{\link{cff}} object.
 }
 \description{
 Create a full and possibly valid \code{\link{cff}} object from a given source. This
-object can be written to a \verb{*.cff} file with \code{\link[=cff_write]{cff_write()}},
-see \strong{Examples}.
+object can be written to a \code{CITATION.cff} file with \code{\link[=cff_write]{cff_write()}}. See
+\strong{Examples}.
 
 Most of the heavy lifting of \CRANpkg{cffr} is done by this function.
 }
 \details{
-If \code{x} is a path to a \code{DESCRIPTION} file or if \code{inst/CITATION} is not present
-on your package, \CRANpkg{cffr} would auto-generate a \code{preferred-citation}
-key using the information provided on that file.
+If \code{x} is a path to a \code{DESCRIPTION} file, or if \code{inst/CITATION} is not
+present in your package, \CRANpkg{cffr} auto-generates a
+\code{preferred-citation} key using the information provided in that file.
 
 By default, only persons whose role in the \code{DESCRIPTION} file of the package
-is author (\code{"aut"}) or maintainer (\code{"cre"}) are considered to be authors
-of the package. The default setting can be controlled via the \code{authors_roles}
-argument. See \strong{Details} on \code{\link[=person]{person()}} to get additional insights
-on person roles.
+is author (\code{"aut"}) or maintainer (\code{"cre"}) are considered package authors.
+The default setting can be controlled via the \code{authors_roles} argument. See
+\strong{Details} on \code{\link[=person]{person()}} for additional information about person roles.
 }
 \examples{
 \donttest{
-# Installed package
+# Installed package.
 cff_create("jsonlite")
 
-# Demo file
+# Demo file.
 demo_file <- system.file("examples/DESCRIPTION_basic", package = "cffr")
 cff_create(demo_file)
 
@@ -101,14 +100,14 @@ cff_create(demo_file, keys = list("contact" = new_contact))
 \href{https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md}{Guide to Citation File Format schema version 1.2.0}.
 \itemize{
 \item \code{\link[=cff_modify]{cff_modify()}} as the recommended way to modify a \code{cff} object.
-\item \code{\link[=cff_write]{cff_write()}} for creating a CFF file.
-\item \code{vignette("cffr", package = "cffr")} shows an introduction on how
-manipulate \code{\link{cff}} objects.
+\item \code{\link[=cff_write]{cff_write()}} for creating a \code{CITATION.cff} file.
+\item \code{vignette("cffr", package = "cffr")} shows an introduction to
+manipulating \code{\link{cff}} objects.
 \item \code{vignette("r-cff", package = "cffr")} provides details on how the
 metadata of a package is mapped to produce a \code{cff} object.
 }
 
-Other core functions of \CRANpkg{cffr}:
+Core \CRANpkg{cffr} workflow:
 \code{\link[=cff]{cff()}},
 \code{\link[=cff_modify]{cff_modify()}},
 \code{\link[=cff_validate]{cff_validate()}}

--- a/man/cff_gha_update.Rd
+++ b/man/cff_gha_update.Rd
@@ -14,10 +14,11 @@ cff_gha_update(path = ".", overwrite = FALSE)
 overwritten?}
 }
 \value{
-Invisible, this function is called by its side effects.
+Invisible. This function is called for its side effects.
 }
 \description{
-This function installs a \href{https://github.com/features/actions}{GitHub Action} on your repository. The action
+This function installs a \href{https://github.com/features/actions}{GitHub Action}
+on your repository. The action
 updates your \code{CITATION.cff} when any of these events occur:
 \itemize{
 \item You publish a new release of the package.
@@ -26,7 +27,7 @@ updates your \code{CITATION.cff} when any of these events occur:
 }
 }
 \details{
-Triggers on your action can be modified, see \href{https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows}{Events that trigger workflows}.
+Triggers on your action can be modified. See \href{https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows}{Events that trigger workflows}.
 }
 \examples{
 \dontrun{
@@ -34,7 +35,7 @@ cff_gha_update()
 }
 }
 \seealso{
-Other Git/GitHub helpers provided by \CRANpkg{cffr}:
+Keep \file{CITATION.cff} up to date:
 \code{\link{cff_git_hook}}
 }
 \concept{git}

--- a/man/cff_git_hook.Rd
+++ b/man/cff_git_hook.Rd
@@ -42,7 +42,7 @@ be triggered even if you have attempted to update your \code{CITATION.cff} file.
 
 This typically occurs when you have updated your \code{DESCRIPTION} or
 \code{inst/CITATION} files, but those changes do not affect your
-\code{CITATION.cff} file (for example, you are adding new dependencies).
+\code{CITATION.cff} file, for example, when you add new dependencies.
 
 In those cases, you can override the check by running
 \verb{git commit --no-verify} in the terminal.
@@ -69,11 +69,11 @@ cff_git_hook_install()
 \itemize{
 \item \code{\link[usethis:use_git_hook]{usethis::use_git_hook()}}, which is the underlying function used by
 \code{cff_git_hook_install()}.
-\item \code{\link[usethis:use_git]{usethis::use_git()}} and related function of \CRANpkg{usethis} for using
+\item \code{\link[usethis:use_git]{usethis::use_git()}} and related functions of \CRANpkg{usethis} for using
 Git with \R packages.
 }
 
-Other Git/GitHub helpers provided by \CRANpkg{cffr}:
+Keep \file{CITATION.cff} up to date:
 \code{\link[=cff_gha_update]{cff_gha_update()}}
 }
 \concept{git}

--- a/man/cff_modify.Rd
+++ b/man/cff_modify.Rd
@@ -48,11 +48,10 @@ cff_validate(x_mod)
 
 }
 \seealso{
-This function is a wrapper of \code{\link[utils:modifyList]{utils::modifyList()}}.
+This function is a wrapper of \code{\link[utils:modifyList]{utils::modifyList()}}. See \code{\link[=cff]{cff()}} for
+creating \code{\link{cff}} objects from scratch.
 
-See \code{\link[=cff]{cff()}} for creating \code{\link{cff}} objects from scratch.
-
-Other core functions of \CRANpkg{cffr}:
+Core \CRANpkg{cffr} workflow:
 \code{\link[=cff]{cff()}},
 \code{\link[=cff_create]{cff_create()}},
 \code{\link[=cff_validate]{cff_validate()}}

--- a/man/cff_read.Rd
+++ b/man/cff_read.Rd
@@ -35,7 +35,7 @@ cff_read_bib(path, encoding = "UTF-8", ...)
 \code{CITATION.cff} file adheres to for providing the citation metadata.}
 
 \item{gh_keywords}{Logical \code{TRUE/FALSE}. If the package is hosted on
-GitHub, would you like to add the repository topics as keywords?}
+GitHub, should the repository topics be added as keywords?}
 
 \item{authors_roles}{Roles to be considered as authors of the package when
 generating the \code{CITATION.cff} file. See \strong{Details}.}
@@ -50,7 +50,7 @@ generating the \code{CITATION.cff} file. See \strong{Details}.}
 \item \code{cff_read_cff_citation()} and \code{cff_read_description()} return an object
 with class \code{cff}.
 \item \code{cff_read_citation()} and \code{cff_read_bib()} return an object of classes
-\code{\link[=cff_ref_lst]{cff_ref_lst, cff}} according to the \code{definitions.references}
+\code{\link[=cff_ref_lst]{cff_ref_lst, cff}} according to the \code{definitions.reference}
 specified in the \href{https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md}{Citation File Format schema}.
 }
 
@@ -80,15 +80,13 @@ For details of \code{cff_read_description()}, see \code{\link[=cff_create]{cff_c
 \subsection{The \code{meta} object}{
 
 Section 1.9 CITATION files of \emph{Writing R Extensions} (R Core Team 2023)
-specifies how to create dynamic \code{CITATION} files using \code{meta} object, hence
-the \code{meta} argument in \code{\link[=cff_read_citation]{cff_read_citation()}} may be needed for reading
-some files correctly.
+specifies how to create dynamic \code{CITATION} files using a \code{meta} object.
+Therefore, the \code{meta} argument in \code{\link[=cff_read_citation]{cff_read_citation()}} may be needed to
+read some files correctly.
 }
 }
 \examples{
-
-# Create a `cff` object from a CFF file.
-
+# Create a `cff` object from a `CITATION.cff` file.
 from_cff_file <- cff_read(system.file("examples/CITATION_basic.cff",
   package = "cffr"
 ))
@@ -103,7 +101,6 @@ from_desc <- cff_read(system.file("examples/DESCRIPTION_basic",
 from_desc
 
 # Create a `cff` object from BibTeX.
-
 if (requireNamespace("bibtex", quietly = TRUE)) {
   from_bib <- cff_read(system.file("examples/example.bib",
     package = "cffr"
@@ -137,10 +134,10 @@ The underlying functions used for reading external files:
 \item \code{\link[bibtex:read.bib]{bibtex::read.bib()}} for BibTeX files (extension \verb{*.bib}).
 }
 
-Other functions for reading external files:
+Read external citation metadata:
 \code{\link[=cff_read_bib_text]{cff_read_bib_text()}}
 
-Other functions for working with BibTeX format:
+Work with BibTeX metadata:
 \code{\link[=as_bibentry]{as_bibentry()}},
 \code{\link[=cff_read_bib_text]{cff_read_bib_text()}},
 \code{\link[=cff_write_bib]{cff_write_bib()}},

--- a/man/cff_read_bib_text.Rd
+++ b/man/cff_read_bib_text.Rd
@@ -16,8 +16,7 @@ cff_read_bib_text(x, encoding = "UTF-8", ...)
 }
 \value{
 An object of classes \code{\link[=cff_ref_lst]{cff_ref_lst, cff}} according to the
-\code{definitions.references} specified in
-the \href{https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md}{Citation File Format schema}.
+\code{definitions.reference} specified in the \href{https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md}{Citation File Format schema}.
 Each element of the \code{cff_ref_lst} object has classes
 \code{\link[=cff_ref]{cff_ref, cff}}.
 }
@@ -59,13 +58,13 @@ if (requireNamespace("bibtex", quietly = TRUE)) {
 \seealso{
 \code{\link[=cff_read_bib]{cff_read_bib()}} for reading \verb{*.bib} files.
 
-Other functions for working with BibTeX format:
+Work with BibTeX metadata:
 \code{\link[=as_bibentry]{as_bibentry()}},
 \code{\link[=cff_read]{cff_read()}},
 \code{\link[=cff_write_bib]{cff_write_bib()}},
 \code{\link[=encoded_utf_to_latex]{encoded_utf_to_latex()}}
 
-Other functions for reading external files:
+Read external citation metadata:
 \code{\link[=cff_read]{cff_read()}}
 }
 \concept{bibtex}

--- a/man/cff_schema.Rd
+++ b/man/cff_schema.Rd
@@ -48,16 +48,11 @@ keys to be used on the \code{preferred-citation} and \code{references} keys.
 }
 }
 \examples{
-
 cff_schema_keys(sorted = TRUE)
-
 # Valid license keys.
 head(cff_schema_keys_license(), 20)
-
 cff_schema_definitions_person()
-
 cff_schema_definitions_entity()
-
 cff_schema_definitions_refs()
 }
 \concept{schemas}

--- a/man/cff_validate.Rd
+++ b/man/cff_validate.Rd
@@ -8,17 +8,17 @@
 cff_validate(x = "CITATION.cff", verbose = TRUE)
 }
 \arguments{
-\item{x}{This is expected to be either a full \code{cff} object created
-with \code{\link[=cff_create]{cff_create()}} or the path to a \code{CITATION.cff} file to be validated.
-In the case of a \verb{*.cff} file it would read with \code{\link[=cff_read_cff_citation]{cff_read_cff_citation()}}.}
+\item{x}{A full \code{cff} object created with \code{\link[=cff_create]{cff_create()}} or the path to a
+\code{CITATION.cff} file to be validated. A \verb{*.cff} file is read with
+\code{\link[=cff_read_cff_citation]{cff_read_cff_citation()}}.}
 
 \item{verbose}{Logical \code{TRUE/FALSE}. When \code{TRUE}, the function displays
 informative messages.}
 }
 \value{
 A message indicating the result of the validation and an invisible value
-\code{TRUE/FALSE}. On error, the result has an attribute \code{"errors"}
-containing the error summary (see \strong{Examples} and \code{\link[=attr]{attr()}}).
+\code{TRUE/FALSE}. On error, the result has an attribute \code{"errors"} containing
+the error summary. See \strong{Examples} and \code{\link[=attr]{attr()}}.
 }
 \description{
 Validate a \code{CITATION.cff} file or a \code{\link{cff}} object using the corresponding \href{https://github.com/citation-file-format/citation-file-format/blob/main/schema.json}{validation schema}.
@@ -52,12 +52,11 @@ df_errors[, c("field", "message")]
 try(cff_validate(system.file("CITATION", package = "cffr")))
 }
 \seealso{
-\href{https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md}{Guide to Citation File Format schema version 1.2.0}.
-
 \code{\link[jsonvalidate:json_validate]{jsonvalidate::json_validate()}}, which is the function that performs the
 validation.
+\href{https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md}{Guide to Citation File Format schema version 1.2.0}.
 
-Other core functions of \CRANpkg{cffr}:
+Core \CRANpkg{cffr} workflow:
 \code{\link[=cff]{cff()}},
 \code{\link[=cff_create]{cff_create()}},
 \code{\link[=cff_modify]{cff_modify()}}

--- a/man/cff_write.Rd
+++ b/man/cff_write.Rd
@@ -39,7 +39,7 @@ in-development \R package.
 \code{CITATION.cff} file adheres to for providing the citation metadata.}
 
 \item{gh_keywords}{Logical \code{TRUE/FALSE}. If the package is hosted on
-GitHub, would you like to add the repository topics as keywords?}
+GitHub, should the repository topics be added as keywords?}
 
 \item{r_citation}{Logical \code{TRUE/FALSE}. When \code{TRUE}, the \R package
 citation (for example, \code{inst/CITATION}) is created or updated.
@@ -67,17 +67,16 @@ A \code{CITATION.cff} file and an (invisible) \code{cff} object.
 }
 \description{
 \strong{This is the core function of the package and likely to be the only one
-you would need when developing a package}.
+you need when developing a package}.
 
-This function writes out a \code{CITATION.cff} file for a given package. This
-function is basically a wrapper around \code{\link[=cff_create]{cff_create()}} to both create the
-\code{\link{cff}} object and write it out to a YAML-formatted file in
-one command.
+This function writes a \code{CITATION.cff} file for a given package. It wraps
+\code{\link[=cff_create]{cff_create()}} to create the \code{\link{cff}} object and write it to a YAML-formatted
+file in one command.
 }
 \details{
 For details of \code{authors_roles}, see \code{\link[=cff_create]{cff_create()}}.
 
-When creating and writing a \code{CITATION.cff} for the first time, the function
+When creating and writing a \code{CITATION.cff} for the first time, this function
 adds the pattern \code{"^CITATION\\.cff$"} to your \code{.Rbuildignore} file.
 }
 \examples{
@@ -96,7 +95,7 @@ file.remove(tmpfile)
 This function unifies the workflow \code{\link[=cff_create]{cff_create()}} + \code{\link[=cff_validate]{cff_validate()}} +
 write a file.
 
-Other functions for creating external files:
+Write citation metadata files:
 \code{\link[=cff_write_bib]{cff_write_bib()}}
 }
 \concept{writing}

--- a/man/cff_write_misc.Rd
+++ b/man/cff_write_misc.Rd
@@ -68,7 +68,6 @@ For security reasons, if the file already exists, the function creates
 a backup copy in the same directory.
 }
 \examples{
-
 bib <- bibentry("Misc",
   title = "My title",
   author = "Fran Pérez"
@@ -83,17 +82,15 @@ cat(readLines(my_temp_bib), sep = "\n")
 cff_write_bib(bib, file = my_temp_bib, ascii = TRUE, append = TRUE)
 
 cat(readLines(my_temp_bib), sep = "\n")
-
-# Create a CITATION file
-
-# Use a system file
+# Create a CITATION file.
+# Use a system file.
 f <- system.file("examples/preferred-citation-book.cff", package = "cffr")
 a_cff <- cff_read(f)
 
 out <- file.path(tempdir(), "CITATION")
 cff_write_citation(a_cff, file = out)
 
-# Check by reading, use meta object
+# Check by reading with a meta object.
 meta <- packageDescription("cffr")
 meta$Encoding <- "UTF-8"
 
@@ -114,13 +111,13 @@ following packages:
 \item \CRANpkg{rbibutils}
 }
 
-Other functions for working with BibTeX format:
+Work with BibTeX metadata:
 \code{\link[=as_bibentry]{as_bibentry()}},
 \code{\link[=cff_read]{cff_read()}},
 \code{\link[=cff_read_bib_text]{cff_read_bib_text()}},
 \code{\link[=encoded_utf_to_latex]{encoded_utf_to_latex()}}
 
-Other functions for creating external files:
+Write citation metadata files:
 \code{\link[=cff_write]{cff_write()}}
 }
 \concept{bibtex}

--- a/man/cffr-package.Rd
+++ b/man/cffr-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Citation File Format ('CFF') version 1.2.0 \doi{10.5281/zenodo.5171937} is a human- and machine-readable file format for software citation metadata. The package provides core utilities to generate and validate this metadata for R packages.
+Citation File Format ('CFF') version 1.2.0 \doi{10.5281/zenodo.5171937} is a human- and machine-readable file format for software citation metadata. The package provides core utilities to generate, read, write and validate this metadata for R packages.
 }
 \seealso{
 Useful links:

--- a/man/chunks/cffclass.Rmd
+++ b/man/chunks/cffclass.Rmd
@@ -68,7 +68,7 @@ class(two_persons[[1]])
 
 # Array of references.
 
-cit <- c(citation(), citation("yaml"))
+cit <- c(citation(), citation("jsonlite"))
 
 ref_list <- as_cff(cit)
 

--- a/man/chunks/cffclass.Rmd
+++ b/man/chunks/cffclass.Rmd
@@ -1,7 +1,3 @@
-[**cffr**](https://cran.r-project.org/package=cffr) implements an S3 object with
-[`class`] `cff`, which is used to represent the information of a `CITATION.cff`
-file in **R**.
-
 Under the hood, a `cff` object is simply a named [`list`] to which we added
 additional methods, most notably [`print`] and [as_cff()].
 
@@ -16,7 +12,7 @@ a_named_list <- list(
   fifth = "with", sixth = "names", "none" = NULL
 )
 
-# As cff
+# Convert to `cff`.
 a_cff_object <- as_cff(a_named_list)
 
 class(a_cff_object)
@@ -26,33 +22,33 @@ a_cff_object
 is.list(a_cff_object)
 ```
 
-[as_cff()] not only converts a `list` to `cff` but also removes items (known as
-`keys` in CFF terminology) that are `NULL` or `NA`.
+[as_cff()] not only converts a `list` to `cff` but also removes items that are
+`NULL` or `NA`. These items are known as `keys` in CFF terminology.
 
-### Sub-classes
+### Subclasses
 
-**cffr** implements two special sub-classes of `cff`, with the aim of
-representing two special types of objects defined in the [CFF
-Schema](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md):
+**cffr** implements two special subclasses of `cff`, which represent two special
+types of objects defined in the [Citation File Format
+schema](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md):
 
--   `definition.person` and `definition.entity`: CFF definitions for sub-lists
-    representing persons or entities. In **cffr**, the sub-class `cff_pers_lst`
-    has been implemented to collect an array of `definition.person/entity`,
-    where each individual person or entity has a sub-class `cff_pers`.
+- `definitions.person` and `definitions.entity`: CFF definitions for sublists
+  representing persons or entities. In **cffr**, the subclass `cff_pers_lst`
+  collects an array of `definitions.person` or `definitions.entity` objects,
+  where each individual person or entity has subclass `cff_pers`.
 
--   Similarly, `definition.reference` is the CFF definition for collecting
-    references to related works and other articles of software used in the
-    development of the main work of the CFF file. This is implemented in
-    **cffr** as a sub-class named `cff_ref_lst` for arrays of
-    `definition.reference`, where each element has a sub-class named `cff_ref`.
+- Similarly, `definitions.reference` is the CFF definition for collecting
+  references to related works and other software used in the development of the
+  main work of the `CITATION.cff` file. In **cffr**, the subclass `cff_ref_lst`
+  represents arrays of `definitions.reference` objects, where each element has
+  subclass `cff_ref`.
 
-These two sub-classes do not provide full valid `cff` objects, but adapt
+These two subclasses do not provide full valid `cff` objects, but adapt
 information to the schema required by CFF:
 
 ```{r}
-# Using the utils::person() function
+# Use the utils::person() function.
 
-## Array
+## Array.
 two_persons <- as_cff_person(
   c(
     person("A", "person", comment = c(ORCID = "0000-0001-8457-4658")),
@@ -64,13 +60,13 @@ two_persons
 
 class(two_persons)
 
-# Single element
+# Single element.
 
 two_persons[[1]]
 
 class(two_persons[[1]])
 
-# Array of references
+# Array of references.
 
 cit <- c(citation(), citation("yaml"))
 
@@ -80,7 +76,7 @@ ref_list
 
 class(ref_list)
 
-# Single element
+# Single element.
 
 ref_list[[1]]
 
@@ -89,8 +85,9 @@ class(ref_list[[1]])
 
 ## Valid `cff` objects
 
-Creating a `cff` object does not ensure its validity according to the [CFF
-Schema](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md):
+Creating a `cff` object does not ensure its validity according to the [Citation
+File Format
+schema](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md):
 
 ```{r}
 class(a_cff_object)
@@ -98,8 +95,8 @@ class(a_cff_object)
 cff_validate(a_cff_object)
 ```
 
-[cff_validate()] gives minimal messages about what's wrong with our `cff` and
-(invisibly) returns the result of the validation (`TRUE/FALSE`).
+[cff_validate()] gives minimal messages about what is wrong with the `cff`
+object and invisibly returns the result of the validation (`TRUE/FALSE`).
 
 We can use [cff_modify()] to add more keys:
 
@@ -112,7 +109,7 @@ cff_valid <- cff_modify(a_cff_object,
 )
 
 
-# Remove invalid keys
+# Remove invalid keys.
 cff_valid <- as_cff(cff_valid[names(cff_valid) %in% cff_schema_keys()])
 
 cff_valid
@@ -164,12 +161,12 @@ as.person(two_persons)
 ### [toBibtex()]
 
 ```{r}
-# For cff
+# For `cff`.
 toBibtex(minimal_cff)
 
-# cff_ref, cff_ref_lst
+# For `cff_ref` and `cff_ref_lst`.
 toBibtex(cit)
 
-# cff_pers, cff_pers_lst
+# For `cff_pers` and `cff_pers_lst`.
 toBibtex(two_persons)
 ```

--- a/man/chunks/person.Rmd
+++ b/man/chunks/person.Rmd
@@ -5,11 +5,11 @@ library(cffr)
 
 ```{r}
 #| comment: ''
-# Don't do
+# Do not use unprotected entity names.
 entity <- "Elephant and Castle"
 as_cff_person(entity)
 
-# Do
+# Protect entity names with braces.
 entity_protect <- "{Elephant and Castle}"
 as_cff_person(entity_protect)
 ```

--- a/man/cran_to_spdx.Rd
+++ b/man/cran_to_spdx.Rd
@@ -17,11 +17,10 @@ A data frame with 86 rows and 2 variables:
 }
 \description{
 A dataset containing the mapping between the \code{License} strings observed
-on CRAN packages and its (approximate) match on the
+on CRAN packages and their approximate match on the
 \href{https://spdx.org/licenses/}{SPDX License List}.
 }
 \examples{
-
 data("cran_to_spdx")
 
 head(cran_to_spdx, 20)

--- a/man/deprecated_cff_bibentry.Rd
+++ b/man/deprecated_cff_bibentry.Rd
@@ -14,14 +14,14 @@ cff_parse_citation(bib)
 A \code{bibentry} in format \code{\link{cff}}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use \code{\link[=as_cff.bibentry]{as_cff.bibentry()}} method
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use the \code{\link[=as_cff.bibentry]{as_cff.bibentry()}}
+method instead.
 }
 \examples{
-
 bib <- citation("base")
 bib
 
-# To cff
+# To cff.
 bib_to_cff <- as_cff(bib)
 bib_to_cff
 
@@ -29,7 +29,7 @@ bib_to_cff
 \seealso{
 \code{\link[=as_cff.bibentry]{as_cff.bibentry()}}
 
-Other deprecated functions:
+Deprecated functions:
 \code{\link[=cff_extract_to_bibtex]{cff_extract_to_bibtex()}},
 \code{\link[=cff_from_bibtex]{cff_from_bibtex()}},
 \code{\link[=cff_parse_person]{cff_parse_person()}},

--- a/man/deprecated_cff_from_bib.Rd
+++ b/man/deprecated_cff_from_bib.Rd
@@ -17,7 +17,7 @@ cff_from_bibtex(x, encoding = "UTF-8", ...)
 
 \item{encoding}{Encoding to be assumed for \code{x}. See \code{\link[=readLines]{readLines()}}.}
 
-\item{...}{Other arguments passed to \code{\link[bibtex:read.bib]{bibtex::read.bib()}}.}
+\item{...}{Arguments passed to \code{\link[=cff_read_bib]{cff_read_bib()}}.}
 }
 \value{
 See \code{\link[=cff_read_bib]{cff_read_bib()}} for reading \verb{*.bib} files and \code{\link[=cff_read_bib_text]{cff_read_bib_text()}}
@@ -50,14 +50,14 @@ if (requireNamespace("bibtex", quietly = TRUE)) {
 
   cff_read_bib_text(x)
 
-  # From a file
+  # From a file.
 
   x2 <- system.file("examples/example.bib", package = "cffr")
   cff_read_bib(x2)
 }
 }
 \seealso{
-Other deprecated functions:
+Deprecated functions:
 \code{\link[=cff_extract_to_bibtex]{cff_extract_to_bibtex()}},
 \code{\link[=cff_parse_citation]{cff_parse_citation()}},
 \code{\link[=cff_parse_person]{cff_parse_person()}},

--- a/man/deprecated_cff_person.Rd
+++ b/man/deprecated_cff_person.Rd
@@ -21,10 +21,10 @@ cff_parse_person_bibtex(person)
 A person in format \code{cff}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use \code{\link[=as_cff_person]{as_cff_person()}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use \code{\link[=as_cff_person]{as_cff_person()}} instead.
 }
 \examples{
-# Create a person object
+# Create a person object.
 a_person <- person(
   given = "First", family = "Author",
   role = c("aut", "cre"),
@@ -40,22 +40,22 @@ cff_person <- as_cff_person(a_person)
 
 cff_person
 
-# Back to person object with S3 method
+# Back to person object with S3 method.
 as.person(cff_person)
 
-# Parse a string
+# Parse a string.
 a_str <- paste0(
   "Julio Iglesias <fake@email.com> ",
   "(<https://orcid.org/0000-0001-8457-4658>)"
 )
 as_cff_person(a_str)
 
-# Several persons
+# Several persons.
 persons <- c(person("Clark", "Kent"), person("Lois", "Lane"))
 
 as_cff_person(persons)
 
-# Or you can use BibTeX style if you prefer
+# Or use BibTeX style.
 
 x <- "Frank Sinatra and Dean Martin and Davis, Jr., Sammy and Joey Bishop"
 
@@ -66,7 +66,7 @@ as_cff_person("Herbert von Karajan")
 \seealso{
 \code{\link[=as_cff_person]{as_cff_person()}}
 
-Other deprecated functions:
+Deprecated functions:
 \code{\link[=cff_extract_to_bibtex]{cff_extract_to_bibtex()}},
 \code{\link[=cff_from_bibtex]{cff_from_bibtex()}},
 \code{\link[=cff_parse_citation]{cff_parse_citation()}},

--- a/man/deprecated_cff_to_bib.Rd
+++ b/man/deprecated_cff_to_bib.Rd
@@ -18,9 +18,9 @@ cff_to_bibtex(x, what = c("preferred", "references", "all"))
 in-development package.
 \item An existing \code{cff} object created with \code{\link[=cff]{cff()}}, \code{\link[=cff_create]{cff_create()}}, or
 \code{\link[=as_cff]{as_cff()}}.
-\item Path to a CITATION.cff file (\code{"CITATION.cff"}).
+\item Path to a \code{CITATION.cff} file (\code{"CITATION.cff"}).
 \item The name of an installed package (\code{"jsonlite"}).
-\item Path to a DESCRIPTION file (\code{"DESCRIPTION"}).
+\item Path to a \code{DESCRIPTION} file (\code{"DESCRIPTION"}).
 }}
 
 \item{what}{Fields to extract from a full \code{cff} object. The value could be:
@@ -41,17 +41,17 @@ See \code{\link[=as_bibentry]{as_bibentry()}}.
 }
 \examples{
 \donttest{
-# From a cff object
+# From a cff object.
 cff_object <- cff()
 
 cff_object
 
-# bibentry object
+# A bibentry object.
 bib <- as_bibentry(cff_object)
 }
 }
 \seealso{
-Other deprecated functions:
+Deprecated functions:
 \code{\link[=cff_from_bibtex]{cff_from_bibtex()}},
 \code{\link[=cff_parse_citation]{cff_parse_citation()}},
 \code{\link[=cff_parse_person]{cff_parse_person()}},

--- a/man/deprecated_write.Rd
+++ b/man/deprecated_write.Rd
@@ -29,14 +29,13 @@ displayed instead.}
 \item{ascii}{Logical. Should entries be written using ASCII characters only?}
 }
 \value{
-Write a file.
+Writes a file.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use \code{\link[=cff_write_bib]{cff_write_bib()}} or
 \code{\link[=cff_write_citation]{cff_write_citation()}} instead.
 }
 \examples{
-
 bib <- bibentry("Misc",
   title = "My title",
   author = "Fran Pérez"
@@ -58,7 +57,7 @@ cat(readLines(my_temp_bib), sep = "\n")
 \item \code{\link[=cff_write_citation]{cff_write_citation()}} for writing \R \code{CITATION} files.
 }
 
-Other deprecated functions:
+Deprecated functions:
 \code{\link[=cff_extract_to_bibtex]{cff_extract_to_bibtex()}},
 \code{\link[=cff_from_bibtex]{cff_from_bibtex()}},
 \code{\link[=cff_parse_citation]{cff_parse_citation()}},

--- a/man/encoded_utf_to_latex.Rd
+++ b/man/encoded_utf_to_latex.Rd
@@ -8,7 +8,7 @@
 encoded_utf_to_latex(x)
 }
 \arguments{
-\item{x}{A string, possibly encoded in UTF-8 encoding system.}
+\item{x}{A string, possibly encoded in UTF-8.}
 }
 \value{
 A string with the corresponding transformations.
@@ -21,7 +21,7 @@ This is a variation of \code{\link[tools:encoded_text_to_latex]{tools::encoded_t
 additional replacements for better compatibility.
 }
 \examples{
-# Full range of supported characters on R
+# Full range of supported characters in R.
 library(tools)
 
 range <- 1:511
@@ -31,12 +31,12 @@ ascii_table <- data.frame(
   utf8 = intToUtf8(range, multiple = TRUE)
 )
 
-# Add latex using base approach
+# Add LaTeX using the base approach.
 ascii_table$latex_base <- encoded_text_to_latex(ascii_table$utf8,
   encoding = "UTF-8"
 )
 
-# With cffr
+# With cffr.
 ascii_table$latex_cffr <- encoded_utf_to_latex(ascii_table$utf8)
 
 ascii_table
@@ -44,7 +44,7 @@ ascii_table
 \seealso{
 \code{\link[tools:encoded_text_to_latex]{tools::encoded_text_to_latex()}}
 
-Other functions for working with BibTeX format:
+Work with BibTeX metadata:
 \code{\link[=as_bibentry]{as_bibentry()}},
 \code{\link[=cff_read]{cff_read()}},
 \code{\link[=cff_read_bib_text]{cff_read_bib_text()}},

--- a/man/roxygen/meta.R
+++ b/man/roxygen/meta.R
@@ -1,12 +1,13 @@
 list(
   rd_family_title = list(
-    core = "Other core functions of \\CRANpkg{cffr}:",
-    reading = "Other functions for reading external files:",
-    writing = "Other functions for creating external files:",
-    bibtex = "Other functions for working with BibTeX format:",
-    schemas = "Other CFF schemas:",
-    git = "Other Git/GitHub helpers provided by \\CRANpkg{cffr}:",
-    deprecated = "Other deprecated functions:",
-    s3method = "Coercing between \\strong{R} classes with \\strong{S3 Methods}:"
+    core = "Core \\CRANpkg{cffr} workflow:",
+    reading = "Read external citation metadata:",
+    writing = "Write citation metadata files:",
+    bibtex = "Work with BibTeX metadata:",
+    schemas = "Inspect Citation File Format schemas:",
+    git = "Keep \\file{CITATION.cff} up to date:",
+    datasets = "\\CRANpkg{cffr} datasets:",
+    deprecated = "Deprecated functions:",
+    s3method = "Coerce between \\R classes:"
   )
 )

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -13,35 +13,38 @@ repo:
 
 home:
   title: cffr | Generate Citation File Format metadata for R packages
-  description: Generate, read and validate Citation File Format metadata for R packages.
+  description: >
+    Generate, read, write and validate Citation File Format metadata for
+    R packages.
 
 reference:
 - title: Core workflow
 - subtitle: Main workflow
   desc: >
-    The main function of the package and likely the only one you need.
+    Create, write and validate a `CITATION.cff` file in one command.
   contents: cff_write
 - subtitle: Other core functions
   desc: Create, modify and validate `cff` objects.
   contents: has_concept("core")
 - subtitle: Citation File Format schema
   desc: >
-    Lists of valid keys and fields as defined by the CFF `schema.json`
+    Inspect valid keys and fields from the Citation File Format schema
     **(v1.2.0)**.
   contents: has_concept("schemas")
-- subtitle: Documentation
+- subtitle: Class system
   desc: >
-    Learn more about the `cff` class system and S3 methods implemented.
+    Learn about the `cff` class system and S3 methods implemented by
+    **cffr**.
   contents: cff_class
 - title: Additional features
-- subtitle: Coercing objects
+- subtitle: Coerce objects
   desc: >
-    Coerce **R** objects to different classes (`cff`, `person`, `bibentry`)
+    Coerce **R** objects to different classes (`cff`, `person` and `bibentry`)
     used by the package.
   contents: has_concept("s3method")
 - subtitle: Read and write files
   desc: >
-    Read and write CFF, BibTeX and related local files.
+    Read and write `CITATION.cff`, BibTeX and R citation files.
   contents:
   - has_concept("reading")
   - has_concept("writing")
@@ -49,12 +52,16 @@ reference:
   desc: >
     Convert between BibTeX markup and CFF objects.
   contents: has_concept("bibtex")
-- subtitle: Continuous integration
+- subtitle: Git and GitHub helpers
   desc: >
-    Keep `CITATION.cff` files synchronized with package metadata.
+    Keep `CITATION.cff` synchronized with package metadata.
   contents: has_concept("git")
 - title: Datasets
+  desc: >
+    Package datasets used for metadata mapping.
   contents: has_concept("datasets")
+- title: Deprecated functions
+  contents: has_concept("deprecated")
 - title: About the package
   contents: cffr-package
 

--- a/tests/testthat/_snaps/as_bibentry.md
+++ b/tests/testthat/_snaps/as_bibentry.md
@@ -3,9 +3,9 @@
     Code
       s <- as_bibentry(a = 1)
     Message
-      x Cannot convert to `bibentry()`: 
+      x Cannot convert to `bibentry()`.
       i argument "bibtype" is missing, with no default
-      ! Returning empty <bibentry>
+      ! Returning an empty <bibentry>.
 
 # as_bibentry NULL
 
@@ -26,14 +26,14 @@
       as_bibentry("invented_package")
     Condition
       Error in `as_bibentry()`:
-      ! Don't know how to extract a <bibentry> from "invented_package". If it is a package, run `install.packages("invented_package")` first.
+      ! Cannot extract a <bibentry> from "invented_package". If it is a package, run `install.packages("invented_package")` first.
 
 # as_bibentry cff
 
     Code
       end <- as_bibentry(a_cff, what = "references")
     Message
-      ! In `x`, did not find anything with `what` = "references". Returning empty <bibentry>.
+      ! In `x`, did not find anything with `what` = "references". Returning an empty <bibentry>.
 
 ---
 

--- a/tests/testthat/_snaps/as_cff.md
+++ b/tests/testthat/_snaps/as_cff.md
@@ -66,7 +66,7 @@
     Code
       noadd <- cff(chocolate = "New York", version = 5)
     Message
-      i Found misspelled keys. Trying to map:
+      i Found misspelled keys. Trying to map them:
       x chocolate: No match, removing.
 
 # Reading full cff

--- a/tests/testthat/_snaps/cff.md
+++ b/tests/testthat/_snaps/cff.md
@@ -1708,7 +1708,7 @@
     Code
       cff(tittle = "a", cff_version = "ar", version = "200", messange = "Fix my keys")
     Message
-      i Found misspelled keys. Trying to map:
+      i Found misspelled keys. Trying to map them:
       v tittle: title
       v messange: message
     Output
@@ -1723,7 +1723,7 @@
       cffobj <- cff(tittle = "a", cff_version = "1.2.0", version = "200", messange = "aa",
         anthor = list(list(`family-names` = "a", `given-names` = "b")))
     Message
-      i Found misspelled keys. Trying to map:
+      i Found misspelled keys. Trying to map them:
       v tittle: title
       v messange: message
       v anthor: authors
@@ -1733,7 +1733,7 @@
     Code
       ss <- cff(tittle = "a", tittle = "ar", version = "200", messange = "Fix my keys")
     Message
-      i Found misspelled keys. Trying to map:
+      i Found misspelled keys. Trying to map them:
       v tittle: title
       v tittle: title
       v messange: message

--- a/tests/testthat/_snaps/cff_modify.md
+++ b/tests/testthat/_snaps/cff_modify.md
@@ -11,7 +11,7 @@
     Code
       xend <- cff_modify(a_cff)
     Message
-      i Arguments `...` are empty. Returning `x`.
+      i No `...` arguments supplied. Returning `x`.
 
 ---
 

--- a/tests/testthat/_snaps/cff_read_bib_text.md
+++ b/tests/testthat/_snaps/cff_read_bib_text.md
@@ -47,5 +47,5 @@
       fromfile <- cff_read_bib_text(tmpbib)
     Message
       ! `x` seems to be a ".bib" file, not a BibTeX entry.
-      i Reading `x` with `cffr:cff_read_bib()`
+      i Reading `x` with `cffr:cff_read_bib()`.
 

--- a/tests/testthat/_snaps/cff_validate.md
+++ b/tests/testthat/_snaps/cff_validate.md
@@ -5,7 +5,7 @@
     Output
       == Validating cff ==============================================================
     Message
-      v Congratulations! This <cff> is valid.
+      v This <cff> is valid.
 
 # Validate error CITATION.cff
 
@@ -14,7 +14,7 @@
     Output
       == Validating cff ==============================================================
     Message
-      x Oops! This <cff> has the following errors:
+      x Validation failed. This <cff> has the following errors:
       * cff/: must NOT have additional properties
       * cff/authors/0: must NOT have additional properties
       * cff/authors/0/orcid: must match pattern "https://orcid\.org/[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]{1}"

--- a/tests/testthat/_snaps/xtra-check-bibtex-ruby.md
+++ b/tests/testthat/_snaps/xtra-check-bibtex-ruby.md
@@ -3,9 +3,9 @@
     Code
       s <- as_bibentry(x)
     Message
-      x Cannot convert to `bibentry()`: 
+      x Cannot convert to `bibentry()`.
       i A bibentry of bibtype 'Book' has to specify the field: publisher
-      ! Returning empty <bibentry>
+      ! Returning an empty <bibentry>.
 
 # preferred-citation-book
 

--- a/tests/testthat/setup-available-packages.R
+++ b/tests/testthat/setup-available-packages.R
@@ -1,0 +1,34 @@
+test_available_packages <- data.frame(
+  Package = c(
+    "bibtex",
+    "cli",
+    "codemetar",
+    "desc",
+    "ggplot2",
+    "jsonlite",
+    "jsonvalidate",
+    "knitr",
+    "lifecycle",
+    "MomTrunc",
+    "options",
+    "quarto",
+    "quint",
+    "resmush",
+    "rmarkdown",
+    "surveillance",
+    "testthat",
+    "usethis",
+    "yaml"
+  ),
+  Repository = "https://cloud.r-project.org/src/contrib"
+)
+
+local_test_available_packages <- function(env = parent.frame()) {
+  testthat::local_mocked_bindings(
+    get_avail_on_init = function() test_available_packages,
+    .package = "cffr",
+    .env = env
+  )
+}
+
+local_test_available_packages(testthat::teardown_env())

--- a/tests/testthat/test-cff_create.R
+++ b/tests/testthat/test-cff_create.R
@@ -399,14 +399,32 @@ test_that("Search package on CRAN", {
   basic_path <- system.file("examples/DESCRIPTION_basic", package = "cffr")
 
   tmp <- tempfile("DESCRIPTION_basic")
-  # Create a temporary file
   file.copy(basic_path, tmp)
 
   newfile <- desc::desc_set("Package", "ggplot2", file = tmp)
+  avail <- data.frame(
+    Package = "ggplot2",
+    Repository = "https://cloud.r-project.org/src/contrib"
+  )
+  repos <- c(CRAN = "https://cloud.r-project.org/")
+  testthat::local_mocked_bindings(
+    get_avail_on_init = function() avail,
+    detect_repos = function() repos,
+    .package = "cffr"
+  )
+
+  expect_equal(clean_str(newfile$get("Package")), "ggplot2")
+  expect_equal(
+    get_desc_repository(newfile),
+    "https://CRAN.R-project.org/package=ggplot2"
+  )
+  expect_equal(
+    get_desc_doi(newfile),
+    "10.32614/CRAN.package.ggplot2"
+  )
 
   a_cff <- cff_create(tmp, gh_keywords = FALSE)
   expect_length(a_cff$repository, 1)
-  expect_equal(clean_str(newfile$get("Package")), "ggplot2")
   expect_equal(a_cff$repository, "https://CRAN.R-project.org/package=ggplot2")
 
   expect_s3_class(a_cff, "cff")
@@ -415,46 +433,29 @@ test_that("Search package on CRAN", {
 })
 
 
-test_that("Search package on r-universe", {
-  skip_on_cran()
-  skip_if_offline()
-
-  basic_path <- system.file("examples/DESCRIPTION_basic", package = "cffr")
-
-  tmp <- tempfile("DESCRIPTION_basic")
-  # Create a temporary file
-  file.copy(basic_path, tmp)
-
-  # Get packages from my r-universe
-  dhh <- "tidyterra"
-
-  newpack <- desc::desc(tmp)
-
-  oldtitle <- clean_str(newpack$get("Package"))
-
-  newtitle <- desc::desc_set("Package", dhh, file = tmp)
-
-  expect_false(oldtitle == clean_str(newtitle$get("Package")))
-
-  # Configure to search on r-universe
+test_that("Search package on r-universe with repository fixtures", {
   newrepos <- c(
     dieghernan = "https://dieghernan.r-universe.dev",
     CRAN = "https://cloud.r-project.org"
   )
-
-  runiverse <- as.data.frame(available.packages(repos = newrepos))
-
-  expect_equal(
-    search_on_repos(dhh, runiverse),
-    "https://dieghernan.r-universe.dev/"
+  runiverse <- data.frame(
+    Package = c("tidyterra", "ggplot2"),
+    Repository = c(
+      "https://dieghernan.r-universe.dev/src/contrib",
+      "https://cloud.r-project.org/src/contrib"
+    )
   )
 
-  # Search now ggplot2, should be canonical url
+  expect_equal(
+    search_on_repos("tidyterra", runiverse, newrepos),
+    "https://dieghernan.r-universe.dev/"
+  )
 
   expect_equal(
     search_on_repos("ggplot2", runiverse, newrepos),
     "https://CRAN.R-project.org/package=ggplot2"
   )
+  expect_null(search_on_repos("not-here", runiverse, newrepos))
 })
 
 
@@ -501,62 +502,9 @@ test_that("Validate keywords", {
 
 
 test_that("Coerce keywords from GH", {
-  skip_on_cran()
-  skip_if_offline()
-  skip_if(
-    nchar(Sys.getenv("GITHUB_TOKEN")) == 0,
-    "No GITHUB_TOKEN environment variable found"
+  expect_null(desc_gh_keywords(NULL, NULL))
+  expect_equal(
+    desc_gh_keywords("keyword1", c("keyword1", "keyword2")),
+    c("keyword1", "keyword2")
   )
-
-  desc_path <- system.file("examples/DESCRIPTION_basic", package = "cffr")
-
-  tmp <- tempfile("DESCRIPTION_keyword_gh")
-
-  copy <- file.copy(desc_path, tmp)
-
-  cffobj <- cff_create(tmp)
-  expect_null(cffobj$keywords)
-
-  expect_true(cff_validate(cffobj, verbose = FALSE))
-
-  # A site with no topics
-  silent <- desc::desc_set(
-    "BugReports",
-    "https://github.com/dieghernan/cfftest/issues",
-    file = tmp
-  )
-
-  cffobjnokeys <- cff_create(tmp)
-  expect_true(cff_validate(cffobjnokeys, verbose = FALSE))
-  expect_null(cffobjnokeys$keywords)
-
-  # Add keywords from url
-  silent <- desc::desc_set(
-    "URL",
-    "https://github.com/ropensci/cffr",
-    file = tmp
-  )
-
-  silent <- desc::desc_set(
-    "BugReports",
-    "https://github.com/ropensci/cffr/issues",
-    file = tmp
-  )
-
-  cffobj1 <- cff_create(tmp)
-  expect_true(cff_validate(cffobj1, verbose = FALSE))
-
-  skip_if(is.null(cffobj1$keywords), "keywords not gathered")
-
-  expect_false(is.null(cffobj1$keywords))
-
-  # Concatenate keywords of both sources
-
-  # Add keywords
-  silent <- desc::desc_set("X-schema.org-keywords", "keyword1", file = tmp)
-
-  cffobj2 <- cff_create(tmp)
-  expect_true(cff_validate(cffobj2, verbose = FALSE))
-
-  expect_true(length(cffobj2$keywords) > length(cffobj1$keywords))
 })

--- a/tests/testthat/test-cff_create.R
+++ b/tests/testthat/test-cff_create.R
@@ -260,6 +260,9 @@ test_that("Parsing Gitlab", {
   expect_length(a_cff$url, 1)
   expect_length(a_cff$identifiers, 0)
   expect_s3_class(a_cff, "cff")
+
+  rvers <- getRversion()
+  skip_if(!grepl("^4.6", rvers), "Snapshot created with R 4.6.*")
   expect_snapshot(a_cff)
   expect_true(cff_validate(a_cff, verbose = FALSE))
 })
@@ -329,6 +332,9 @@ test_that("Parsing two maintainers", {
   expect_length(a_cff$contact, 2)
 
   expect_s3_class(a_cff, "cff")
+
+  rvers <- getRversion()
+  skip_if(!grepl("^4.6", rvers), "Snapshot created with R 4.6.*")
   expect_snapshot(a_cff)
   expect_true(cff_validate(a_cff, verbose = FALSE))
 })
@@ -385,12 +391,16 @@ test_that("Parsing Posit Package Manager", {
     keys = list(references = NULL)
   )
 
+  expect_s3_class(a_cff, "cff")
+
+  rvers <- getRversion()
+  skip_if(!grepl("^4.6", rvers), "Snapshot created with R 4.6.*")
   expect_length(a_cff$repository, 1)
   expect_identical(
     a_cff$repository,
     "https://CRAN.R-project.org/package=resmush"
   )
-  expect_s3_class(a_cff, "cff")
+
   expect_snapshot(a_cff)
   expect_true(cff_validate(a_cff, verbose = FALSE))
 })

--- a/tests/testthat/test-cff_read.R
+++ b/tests/testthat/test-cff_read.R
@@ -53,20 +53,180 @@ test_that("cff_read DESCRIPTION", {
 
   expect_identical(f1_1, f2_1)
 
-  skip_on_cran()
-  # With gh keywords
-  f <- system.file(
-    "examples/DESCRIPTION_posit_package_manager",
-    package = "cffr"
+  field_list <- list(
+    "repository-code" = "https://github.com/ropensci/cffr"
   )
-  fno <- cff_read_description(f, gh_keywords = FALSE)
-  f2 <- cff_read_description(f, gh_keywords = TRUE)
+  expect_equal(
+    gh_topics_api_url(field_list),
+    "https://api.github.com/repos/ropensci/cffr"
+  )
+})
 
-  # In some instances keywords are not retrieved
-  skip_if(is.null(f2$keywords), "keywords not gathered")
+test_that("DESCRIPTION URL helpers are deterministic", {
+  issues <- c(
+    "https://github.com/ropensci/cffr/issues",
+    "https://gitlab.com/org/pkg/-/issues"
+  )
+  expect_equal(
+    desc_clean_issue_url(issues),
+    c("https://github.com/ropensci/cffr", "https://gitlab.com/org/pkg")
+  )
 
-  expect_false(is.null(f2$keywords))
-  expect_gt(length(f2$keywords), length(fno$keywords))
+  urls <- c(
+    "https://pkgdown.example.org",
+    "https://codeberg.org/org/pkg",
+    "https://docs.example.org"
+  )
+  expect_equal(desc_repository_url_index(urls), 2)
+
+  primary <- desc_primary_url(urls[-2], "https://codeberg.org/org/pkg")
+  expect_equal(primary$url, "https://pkgdown.example.org")
+  expect_equal(primary$remaining, "https://docs.example.org")
+
+  fallback <- desc_primary_url(character(0), "https://github.com/org/pkg")
+  expect_equal(fallback$url, "https://github.com/org/pkg")
+  expect_equal(fallback$remaining, character(0))
+
+  identifiers <- desc_url_identifiers(
+    c("https://a.example", "https://b.example")
+  )
+  expect_equal(
+    identifiers,
+    list(
+      list(type = "url", value = "https://a.example"),
+      list(type = "url", value = "https://b.example")
+    )
+  )
+  expect_null(desc_url_identifiers(character(0)))
+  expect_equal(
+    desc_gh_keywords(c("r", "metadata"), c("metadata", "citation")),
+    c("r", "metadata", "citation")
+  )
+})
+
+test_that("DESCRIPTION repository helpers accept fixtures", {
+  basic_path <- system.file("examples/DESCRIPTION_basic", package = "cffr")
+
+  tmp <- tempfile("DESCRIPTION_basic")
+  file.copy(basic_path, tmp)
+
+  pkg <- desc::desc_set("Package", "fixturepkg", file = tmp)
+  avail <- data.frame(
+    Package = "fixturepkg",
+    Repository = "https://cloud.r-project.org/src/contrib"
+  )
+  repos <- c(CRAN = "https://cloud.r-project.org/")
+  testthat::local_mocked_bindings(
+    get_avail_on_init = function() avail,
+    detect_repos = function() repos,
+    .package = "cffr"
+  )
+
+  expect_equal(
+    cran_package_url("fixturepkg"),
+    "https://CRAN.R-project.org/package=fixturepkg"
+  )
+  expect_equal(
+    get_desc_repository(pkg),
+    "https://CRAN.R-project.org/package=fixturepkg"
+  )
+  expect_equal(
+    get_desc_doi(pkg),
+    "10.32614/CRAN.package.fixturepkg"
+  )
+})
+
+test_that("DESCRIPTION DOI returns NULL outside known repositories", {
+  basic_path <- system.file("examples/DESCRIPTION_basic", package = "cffr")
+
+  tmp <- tempfile("DESCRIPTION_basic")
+  file.copy(basic_path, tmp)
+
+  pkg <- desc::desc_set("Package", "fixturepkg", file = tmp)
+  empty_avail <- data.frame(
+    Package = character(0),
+    Repository = character(0)
+  )
+  testthat::local_mocked_bindings(
+    get_avail_on_init = function() empty_avail,
+    detect_repos = function() c(CRAN = "https://cloud.r-project.org/"),
+    .package = "cffr"
+  )
+
+  expect_null(get_desc_doi(pkg))
+})
+
+test_that("GitHub topics API URL is built without network calls", {
+  x <- c("repository-code" = "https://github.com/ropensci/cffr")
+  expect_equal(
+    gh_topics_api_url(x),
+    "https://api.github.com/repos/ropensci/cffr"
+  )
+
+  testthat::local_mocked_bindings(
+    fetch_gh_topics = function(api_url) {
+      expect_equal(api_url, "https://api.github.com/repos/ropensci/cffr")
+      c("r", "citation", "r")
+    },
+    .package = "cffr"
+  )
+
+  expect_equal(get_gh_topics(x), c("r", "citation"))
+})
+
+test_that("GitHub topics returns NULL when API has no topics", {
+  x <- c("repository-code" = "https://github.com/ropensci/cffr")
+
+  testthat::local_mocked_bindings(
+    fetch_gh_topics = function(...) {
+      list()
+    },
+    .package = "cffr"
+  )
+
+  expect_null(get_gh_topics(x))
+})
+
+test_that("GitHub topics returns NULL outside GitHub repositories", {
+  x <- c("repository-code" = "https://gitlab.com/ropensci/cffr")
+
+  testthat::local_mocked_bindings(
+    fetch_gh_topics = function(...) {
+      stop("fetch_gh_topics() should not be called")
+    },
+    .package = "cffr"
+  )
+
+  expect_null(get_gh_topics(x))
+})
+
+test_that("GitHub topics returns NULL when the API request fails", {
+  x <- c("repository-code" = "https://github.com/ropensci/cffr")
+
+  testthat::local_mocked_bindings(
+    fetch_gh_topics = function(...) {
+      NULL
+    },
+    .package = "cffr"
+  )
+
+  expect_null(get_gh_topics(x))
+})
+
+test_that("GitHub topics are cleaned before being used as keywords", {
+  x <- c("repository-code" = "https://github.com/ropensci/cffr")
+
+  testthat::local_mocked_bindings(
+    fetch_gh_topics = function(...) {
+      c(" R ", "", "citation", "R")
+    },
+    .package = "cffr"
+  )
+
+  expect_equal(
+    get_gh_topics(x),
+    c("R", "citation")
+  )
 })
 
 

--- a/tests/testthat/test-cff_read.R
+++ b/tests/testthat/test-cff_read.R
@@ -3,7 +3,7 @@ test_that("Test errors on cff_read", {
   expect_snapshot(cff_read("abcde"), error = TRUE)
 
   f <- system.file("schema/schema.json", package = "cffr")
-  expect_error(cff_read(f), "Don't recognize the file type of")
+  expect_error(cff_read(f), "Cannot recognize the file type of")
 })
 
 test_that("cff_read citation.cff", {
@@ -207,7 +207,7 @@ test_that("Corrupt CITATION", {
   tmp <- tempfile("CITATION")
   writeLines("I am a bad CITATION", tmp)
   expect_message(
-    expect_message(anull <- cff_read(tmp), "It was not possible to read"),
+    expect_message(anull <- cff_read(tmp), "Could not read"),
     "Cannot read"
   )
   expect_null(anull)

--- a/tests/testthat/test-utils-create.R
+++ b/tests/testthat/test-utils-create.R
@@ -59,3 +59,12 @@ test_that("Merge DESCRIPTION wrong url with CITATION_dx", {
     merged[["preferred-citation"]]$url
   )
 })
+
+test_that("Utils coverage", {
+  skip_on_cran()
+  mod <- list(`date-released` = "1995-02-01")
+  expect_identical(cff_dependency_year(mod), "1995")
+
+  mod2 <- list(`date-released` = "1904/12/30")
+  expect_identical(cff_dependency_year(mod2), "1904")
+})

--- a/tests/testthat/test-utils-create.R
+++ b/tests/testthat/test-utils-create.R
@@ -33,6 +33,9 @@ test_that("Check dependencies", {
   })
 
   class(selected) <- "cff"
+
+  rvers <- getRversion()
+  skip_if(!grepl("^4.6", rvers), "Snapshot created with R 4.6.*")
   expect_snapshot(print(selected))
 })
 

--- a/tests/testthat/test-utils-create.R
+++ b/tests/testthat/test-utils-create.R
@@ -61,10 +61,37 @@ test_that("Merge DESCRIPTION wrong url with CITATION_dx", {
 })
 
 test_that("Utils coverage", {
-  skip_on_cran()
+  deps <- data.frame(
+    package = c("foo", "foo", "bar"),
+    version = c("*", "1.0", "2.0"),
+    type = c("Imports", "Suggests", "Depends")
+  )
+  rows <- cff_dependency_rows(deps)
+
+  expect_equal(rows$package, c("foo", "foo", "bar"))
+  expect_equal(rows$version_clean, c("", "1.0", "2.0"))
+  expect_equal(rows$scope, c("Imports", "Imports", "Depends"))
+
   mod <- list(`date-released` = "1995-02-01")
   expect_identical(cff_dependency_year(mod), "1995")
 
   mod2 <- list(`date-released` = "1904/12/30")
   expect_identical(cff_dependency_year(mod2), "1904")
+
+  avail <- data.frame(Package = c("foo", "stats"))
+  testthat::local_mocked_bindings(
+    get_avail_on_init = function() avail,
+    .package = "cffr"
+  )
+  expect_true(is_cran_dependency("foo"))
+  expect_false(is_cran_dependency("stats"))
+  expect_false(is_cran_dependency("bar"))
+
+  ordered <- drop_null(cff_dependency_order(list(
+    year = "2025",
+    repository = "https://example.org/repo",
+    title = "foo",
+    type = "software"
+  )))
+  expect_equal(names(ordered), c("type", "title", "repository", "year"))
 })

--- a/vignettes/bibtex-cff.qmd
+++ b/vignettes/bibtex-cff.qmd
@@ -43,8 +43,7 @@ table_master <- read.csv(p2file)
 ```
 
 ::: callout-important
-Generative AI tools were used to assist in producing some of the material in
-this article.
+Generative AI tools were used to assist with parts of this article.
 :::
 
 ## Citation
@@ -80,11 +79,10 @@ In modern research workflows, both formats frequently coexist. BibTeX remains
 dominant in academic publishing pipelines, while CFF is increasingly adopted by
 infrastructure platforms such as GitHub and Zenodo.
 
-The **cffr** package [@hernangomez2021] provides a deterministic mapping
-(crosswalk) between BibTeX and CFF, enabling practical interoperability. Due to
-fundamental differences in their data models, this mapping is not bijective and
-may involve structural transformations, heuristic parsing and controlled
-information loss.
+**cffr** [@hernangomez2021] provides a deterministic mapping (crosswalk) between
+BibTeX and CFF, enabling practical interoperability. Due to fundamental
+differences in their data models, this mapping is not bijective and may involve
+structural transformations, heuristic parsing and controlled information loss.
 
 ## Conceptual differences between BibTeX and CFF
 
@@ -214,12 +212,13 @@ Two keys play a central role in CFF reference modeling:
 - `references`: Lists related creative works, analogous to references in a
   scholarly article.
 
-Both keys expect `definition-reference` objects, as defined in the [CFF schema
+Both keys expect `definitions.reference` objects, as defined in the [CFF schema
 guide](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#preferred-citation).
 These objects support explicit typing, metadata nesting and structured
 identifiers, in contrast to BibTeX’s flat field model.
 
-The following table summarizes the valid keys for CFF `definition-reference`:
+The following table summarizes the valid keys for CFF `definitions.reference`
+objects:
 
 ```{r}
 #| label: tbl-refkeys
@@ -227,7 +226,7 @@ The following table summarizes the valid keys for CFF `definition-reference`:
 #| message: false
 #| warning: false
 #| results: asis
-#| tbl-cap: "Valid keys in CFF `definition-reference` objects"
+#| tbl-cap: "Valid keys in CFF `definitions.reference` objects"
 library(cffr)
 
 # Fill with blanks.
@@ -257,8 +256,8 @@ The mapping implemented in **cffr** follows a three‑step pipeline:
 3.  Serialize the result into CFF (and vice versa).
 
 Whenever possible, mappings are deterministic. However, some fields require
-heuristic parsing, particularly when normalizing names, dates or page ranges.
-As a result, semantic round‑trip reversibility is not guaranteed, even when the
+heuristic parsing, particularly when normalizing names, dates or page ranges. As
+a result, semantic round‑trip reversibility is not guaranteed, even when the
 conversion process itself is reproducible.
 
 ```{r}
@@ -375,9 +374,9 @@ formatting (e.g., `book`, `edition`) is used for CFF keys.
 
 ## Proposed crosswalk
 
-The **cffr** package provides utilities for mapping BibTeX entries (via
-`bibentry()`) to CFF and back. This section describes how the crosswalk is
-implemented, partially informed by @Haines_Ruby_CFF_Library_2021[^2].
+**cffr** provides utilities for mapping BibTeX entries (via `bibentry()`) to CFF
+and back. This section describes how the crosswalk is implemented, partially
+informed by @Haines_Ruby_CFF_Library_2021[^2].
 
 The crosswalk is primarily defined for BibTeX to CFF conversion. Reverse mapping
 is a best-effort approximation and may be lossy.
@@ -433,11 +432,11 @@ The previous mapping has the following specifications:
 
 - **\@book**, **\@inbook** and **\@incollection** are closely related in
   BibTeX[^3]. While **\@inbook** and **\@incollection** both reference parts of
-  a **\@book**, the former is used for citing sections, chapters, pages or
-  other specific parts, whereas the latter is used for citing parts with a
-  specific title. Since CFF allows keys `type: book` and
-  `collection-type: book`, we may utilize a combination of these fields to tag
-  each entry type in CFF accordingly.
+  a **\@book**, the former is used for citing sections, chapters, pages or other
+  specific parts, whereas the latter is used for citing parts with a specific
+  title. Since CFF allows keys `type: book` and `collection-type: book`, we may
+  utilize a combination of these fields to tag each entry type in CFF
+  accordingly.
 - **\@mastersthesis** and **\@phdthesis** are tagged using a combination of
   `type: thesis` and `thesis-type` keys.
 
@@ -503,8 +502,8 @@ We provide more detail on some of the mappings presented in the table above:
   final mappings in CFF. When mapping from CFF to BibTeX, we propose to follow
   the same entry-based logic, using the key `location` as a fallback value when
   mapping to **address**.
-- Because of the complexity mentioned above, **institution,
-  organization** and **school** are mapped to `institution`.
+- Because of the complexity mentioned above, **institution, organization** and
+  **school** are mapped to `institution`.
 - **series** is mapped to `collection-title` only on those entries that do not
   require **booktitle**. In practice, this means that `collection-title`
   corresponds to **booktitle** (for **\@incollection** and **\@inproceedings**),
@@ -624,18 +623,18 @@ toBibtex(cff_read_bib_text(bib))
 
 ### \@book / \@inbook {#book-inbook}
 
-In terms of the fields required in BibTeX, the primary difference between
-**\@book** and **\@inbook** is that **\@inbook** requires a **chapter** or
-**page** field, while **\@book** does not even allow these fields as optional.
-Therefore, we propose that an **\@inbook** entry in CFF be treated as a
-**\@book** with the following supplementary fields:
+In terms of fields required in BibTeX, the primary difference between **\@book**
+and **\@inbook** is that **\@inbook** requires a **chapter** or **page** field,
+while **\@book** does not even allow these fields as optional. Therefore, we
+propose that an **\@inbook** entry in CFF be treated as a **\@book** with the
+following supplementary fields:
 
 1.  `section`: To denote the specific **chapter** within the book.
 2.  `start`/`end`: To indicate the range of **pages** covered by the section.
 
-Additionally, note that in CFF, the **series** field corresponds to
-`collection-title` and the **address** field represents the `publisher`'s
-`address`. Finally, the key `collection-type` is populated with `book-series`.
+In CFF, the **series** field corresponds to `collection-title` and the
+**address** field represents the `publisher`'s `address`. Finally, the key
+`collection-type` is populated with `book-series`.
 
 ```{r}
 #| label: tbl-model_book
@@ -752,9 +751,8 @@ toBibtex(cff_read_bib_text(bib))
 
 ### \@conference / \@inproceedings {#conf_inproc}
 
-Note that in this case, **organization** is mapped to `institution`.
-Additionally, **series** is ignored because there is no clear mapping in CFF for
-this field.
+In this case, **organization** is mapped to `institution`. **series** is ignored
+because there is no clear mapping in CFF for this field.
 
 ```{r}
 #| label: tbl-model_inproceedings
@@ -808,7 +806,7 @@ is a `type: generic` in CFF with a `collection-title` key. The `generic` type is
 used as a fallback when no semantically equivalent CFF type exists.
 
 Additionally, **series** and **type** are ignored because there is no clear
-mapping in CFF for this field.
+mapping in CFF for these fields.
 
 ```{r}
 #| label: tbl-model_incollection
@@ -977,7 +975,7 @@ toBibtex(cff_read_bib_text(bib))
 
 ### \@misc
 
-The crosswalk of **\@misc** does not require any special treatment. This
+The crosswalk for **\@misc** does not require any special treatment. This
 **entry** does not require any **field**.
 
 Note also that it is mapped to `type: generic` as [**\@incollection**](#incol),
@@ -1074,7 +1072,7 @@ toBibtex(cff_read_bib_text(bib))
 
 ### \@techreport
 
-The crosswalk of **\@techreport** does not require any special treatment.
+The crosswalk for **\@techreport** does not require any special treatment.
 
 ```{r}
 #| label: tbl-model_techreport
@@ -1119,7 +1117,7 @@ toBibtex(cff_read_bib_text(bib))
 
 ### \@unpublished
 
-The crosswalk of **\@unpublished** does not require any special treatment.
+The crosswalk for **\@unpublished** does not require any special treatment.
 
 ```{r}
 #| label: tbl-model_unpublished
@@ -1192,8 +1190,8 @@ field. Moreover, both BibTeX **\@incollection** and BibLaTeX **\@inbook**
 emphasize its reference to *"a part of a book (...) with its own title"*.
 
 In this document, the proposed crosswalk ensures full compatibility with BibTeX.
-Hence, we propose to consider a BibLaTeX **\@inbook** entry as equivalent to a
-BibTeX **\@incollection**, given the congruence in their definitions and field
+Therefore, we propose to consider a BibLaTeX **\@inbook** entry as equivalent to
+a BibTeX **\@incollection**, given the congruence in their definitions and field
 requirements.
 
 **Round-trip**

--- a/vignettes/cffr.qmd
+++ b/vignettes/cffr.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Manipulating Citations with cffr"
+title: "Manipulating citations with cffr"
 description: Learn how to modify `cff` objects.
 toc: true
 bibliography: REFERENCES.bib
@@ -21,9 +21,8 @@ knitr:
 library(cffr)
 ```
 
-The **cffr** package is designed for **R** package developers. The main goal of
-**cffr** is to create a `CITATION.cff` file using metadata from the following
-files:
+**cffr** is designed for **R** package developers. The main goal of **cffr** is
+to create a `CITATION.cff` file using metadata from the following files:
 
 - Your `DESCRIPTION` file.
 - If available, the citation information located in `inst/CITATION`.
@@ -37,7 +36,6 @@ developers can include them in their repositories to let others know how to
 correctly cite their software.
 
 This format is gaining popularity within the software citation ecosystem.
-Recently,
 [GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files),
 [Zenodo](https://citation-file-format.github.io/#/supported-by-zenodo-) and
 [Zotero](https://citation-file-format.github.io/#/supported-by-zotero-) have
@@ -71,7 +69,7 @@ library(cffr)
 
 cff_write()
 
-# You are done.
+# Done.
 ```
 
 Under the hood, `cff_write()` performs these tasks:
@@ -81,12 +79,12 @@ Under the hood, `cff_write()` performs these tasks:
 - Writes a `CITATION.cff` file.
 - Validates the result using `cff_validate()`.
 
-Congratulations! Now you have a full `CITATION.cff` file for your **R** package.
+You now have a complete `CITATION.cff` file for your **R** package.
 
 ## Modifying your `CITATION.cff` file
 
-You can easily customize the `cff` object (a custom **cffr** class) using the
-coercion system provided in the package, as well as the `keys` argument.
+You can customize the `cff` object (a custom **cffr** class) using the coercion
+system provided in the package, as well as the `keys` argument.
 
 We create a `cff` object using `cff()` (for demonstration only) and then add or
 modify its contents.
@@ -186,7 +184,7 @@ add two references, one created with `bibentry()` and another with `citation()`:
 
 cff_schema_definitions_refs()
 
-# Automatic coercion from another R package.
+# Automatic coercion from another **R** package.
 base_r <- citation("base")
 
 bib <- bibentry(

--- a/vignettes/joss-paper.qmd
+++ b/vignettes/joss-paper.qmd
@@ -1,7 +1,7 @@
 ---
 title: "cffr: Generate Citation File Format Metadata for R Packages"
 subtitle: "JOSS paper"
-description: Paper published on The Journal of Open Source Software.
+description: Paper published in the Journal of Open Source Software.
 keywords:
   - R
   - cff
@@ -36,21 +36,21 @@ vignette: >
 
 ## Summary
 
-The Citation File Format project [@druskat_citation_2021] defines a
-standardized format for providing citation metadata for software or datasets in
-plain text files that are easy for both humans and machines to read.
+The Citation File Format project [@druskat_citation_2021] defines a standardized
+format for providing citation metadata for software or datasets in plain text
+files that are easy for both humans and machines to read.
 
 This metadata format is being adopted by GitHub as the primary format for its
 built-in citation support [@github_about_citation]. Other leading archives for
 scientific software, including Zenodo and Zotero [@druskat_stephan_making_2021],
-have also included support for CITATION.cff files in their GitHub integration.
+have also included support for `CITATION.cff` files in their GitHub integration.
 
-The **cffr** package provides utilities to generate and validate these
-CITATION.cff files automatically for R [@R_2021] packages by parsing the
-DESCRIPTION file and the native R citation file. The package also includes
-utilities and examples for parsing components such as persons and additional
-citations, plus several vignettes that illustrate basic package usage and
-technical details about the metadata extraction process.
+**cffr** provides utilities to generate and validate these `CITATION.cff` files
+automatically for **R** [@R_2021] packages by parsing the `DESCRIPTION` file and
+the native **R** citation file. The package also includes utilities and examples
+for parsing components such as persons and additional citations, plus several
+vignettes that illustrate basic package usage and technical details about the
+metadata extraction process.
 
 ## Statement of need
 
@@ -69,15 +69,15 @@ Some of the main reasons for citing software used in research are:
     Receiving credit for software development should be no different from the
     credit received in other formats, such as books or articles.
 
-CITATION.cff files provide clear citation rules for software. The format is easy
-to read by humans and can also be parsed by appropriate software. GitHub's
+`CITATION.cff` files provide clear citation rules for software. The format is
+easy to read by humans and can also be parsed by appropriate software. GitHub's
 adoption of this format sends a strong message that research software is worthy
 of citation and therefore deserves credit.
 
-The **cffr** package allows R software developers to create CITATION.cff files
-from metadata already included in the package. It also includes validation tools
-from the **jsonvalidate** package [@jsonvalidate2021], which allow developers to
-assess the validity of the file created using the latest CFF schema.json.
+**cffr** allows **R** software developers to create `CITATION.cff` files from
+metadata already included in the package. It also includes validation tools from
+the **jsonvalidate** package [@jsonvalidate2021], which allow developers to
+assess the validity of the file created using the latest CFF schema.
 
 ## Acknowledgements
 
@@ -85,9 +85,9 @@ I would like to thank [Carl
 Boettiger](https://ropensci.org/author/carl-boettiger/), [Maëlle
 Salmon](https://ropensci.org/author/ma%C3%ABlle-salmon/) and the [rest of the
 contributors](https://github.com/ropensci/codemetar/graphs/contributors) of the
-**codemetar** package [@codemetar2021]. This package was the primary
-inspiration for developing **cffr** and shares a common goal of increasing
-awareness of the efforts of software developers.
+**codemetar** package [@codemetar2021]. This package was the primary inspiration
+for developing **cffr** and shares a common goal of increasing awareness of the
+efforts of software developers.
 
 I would also like to thank [João Martins](https://zambujo.github.io/) and [Scott
 Chamberlain](https://ropensci.org/author/scott-chamberlain/) for thorough

--- a/vignettes/r-cff.qmd
+++ b/vignettes/r-cff.qmd
@@ -34,9 +34,9 @@ version
 ## Summary {#summary}
 
 This section summarizes the fields that **cffr** can coerce and the original
-source of information for each one. The details for each key are presented in
-the next section. The assessment of fields is based on the [Guide to
-Citation File Format schema version
+source of information for each one. Details for each key are presented in the
+next section. The assessment of fields is based on the [Guide to Citation File
+Format schema version
 1.2.0](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#valid-keys)
 [@druskat_citation_2021].
 
@@ -46,7 +46,7 @@ Citation File Format schema version
 #| tbl-cap: "cffr and R packages: Conversion table"
 keys <- cff_schema_keys(sorted = TRUE)
 origin <- vector(length = length(keys))
-origin[keys == "cff-version"] <- "argument on function"
+origin[keys == "cff-version"] <- "function argument"
 origin[keys == "type"] <- "Fixed value: 'software'"
 origin[keys == "identifiers"] <- "DESCRIPTION/CITATION files"
 origin[keys == "references"] <- "DESCRIPTION/CITATION files"
@@ -98,7 +98,7 @@ This key is extracted from the `"Description"` field of the `DESCRIPTION` file.
 #| label: abstract
 library(cffr)
 
-# Create `cff` for YAML.
+# Create a `cff` object for YAML.
 
 cff_obj <- cff_create("rmarkdown")
 
@@ -128,7 +128,7 @@ pkg <- desc::desc(path)
 # See the listed persons.
 pkg$get_authors()
 
-# Default behavior, use authors and creators (maintainers).
+# Default behavior: use authors and creators (maintainers).
 cff_obj <- cff_create(path)
 cff_obj$authors
 
@@ -300,13 +300,13 @@ X-schema.org-keywords: keyword1, keyword2, keyword3
 nokeywords <- system.file("examples/DESCRIPTION_basic", package = "cffr")
 tmp2 <- tempfile("DESCRIPTION")
 
-# Create a temporary file
+# Create a temporary file.
 file.copy(nokeywords, tmp2)
 
 pkgnokeywords <- desc::desc(tmp2)
 cffnokeywords <- cff_create(tmp2)
 
-# Won't appear
+# This will not appear.
 cat(cffnokeywords$keywords)
 
 pkgnokeywords
@@ -442,10 +442,10 @@ Back to @tbl-summary.
 ### repository
 
 This key is extracted from the `"Repository"` field of the `DESCRIPTION` file.
-Usually, this field is auto-populated when a package is hosted on a repository
-(like **CRAN** or the [r-universe](https://r-universe.dev/search)). For packages
-without this field in the `DESCRIPTION` (which is the typical case for an
-in-development package), **cffr** tries to find the package in any of the
+Usually, this field is automatically populated when a package is hosted on a
+repository (like **CRAN** or the [r-universe](https://r-universe.dev/search)).
+For packages without this field in the `DESCRIPTION` (which is the typical case
+for an in-development package), **cffr** tries to find the package in any of the
 default repositories specified in `options("repos")`.
 
 In the case of [Bioconductor](https://bioconductor.org/) packages, those are
@@ -557,7 +557,7 @@ title <- paste0("NAME_OF_THE_PACKAGE", ": ", "TITLE_OF_THE_PACKAGE")
 
 ```{r}
 #| label: title
-# Installed package
+# Installed package.
 
 cat(cff_create("testthat")$title)
 ```


### PR DESCRIPTION
## Summary

- Refactor internal helpers for clearer source handling, CFF object construction and person/BibTeX utilities.
- Align roxygen2 structure, generated `man/` files, README, vignettes, `DESCRIPTION` and pkgdown reference metadata.
- Improve user-facing `cli` messages and update snapshots/generated metadata to match the revised wording.
- Document that AI assistance was used for the internal refactor and documentation review.

## Validation

- `devtools::load_all(); lintr::lint_package()`
- `devtools::load_all(); devtools::document()`
- `devtools::load_all(); pkgdown::check_pkgdown()`
- `quarto render README.qmd`

`devtools::load_all()` emitted a CRAN index access warning locally, but the checks completed successfully.
