### PR TITLE
Preserve extracted package metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -102,6 +102,7 @@ references:
     name: R Foundation for Statistical Computing
     website: https://ror.org/05qewa988
     address: Vienna, Austria
+  year: '2026'
   doi: 10.32614/R.manuals
   version: '>= 4.1.0'
 - type: software
@@ -113,6 +114,7 @@ references:
   - family-names: Csárdi
     given-names: Gábor
     email: gabor@posit.co
+  year: '2026'
   doi: 10.32614/CRAN.package.cli
   version: '>= 2.0.0'
 - type: software
@@ -129,6 +131,7 @@ references:
   - family-names: Hester
     given-names: Jim
     email: james.f.hester@gmail.com
+  year: '2023'
   doi: 10.32614/CRAN.package.desc
   version: '>= 1.3.0'
 - type: software
@@ -141,6 +144,7 @@ references:
     given-names: Jeroen
     email: jeroenooms@gmail.com
     orcid: https://orcid.org/0000-0002-4035-0289
+  year: '2025'
   doi: 10.32614/CRAN.package.jsonlite
   version: '>= 1.7.2'
 - type: software
@@ -158,6 +162,7 @@ references:
     given-names: Mathias
   - family-names: Poberezkin
     given-names: Evgeny
+  year: '2025'
   doi: 10.32614/CRAN.package.jsonvalidate
   version: '>= 1.1.0'
 - type: software
@@ -170,6 +175,7 @@ references:
     name: R Foundation for Statistical Computing
     website: https://ror.org/05qewa988
     address: Vienna, Austria
+  year: '2026'
   doi: 10.32614/R.manuals
 - type: software
   title: 'yaml: Methods to Convert R Data to YAML and Back'
@@ -181,6 +187,7 @@ references:
     given-names: Jeremy
   - family-names: Simonov
     given-names: Kirill
+  year: '2025'
   doi: 10.32614/CRAN.package.yaml
   version: '>= 2.2.1'
 - type: software
@@ -201,6 +208,7 @@ references:
     given-names: James Joseph
     email: balamut2@illinois.edu
     orcid: https://orcid.org/0000-0003-2826-8458
+  year: '2026'
   doi: 10.32614/CRAN.package.bibtex
   version: '>= 0.5.0'
 - type: software
@@ -213,6 +221,7 @@ references:
     given-names: Yihui
     email: xie@yihui.name
     orcid: https://orcid.org/0000-0003-0645-5666
+  year: '2025'
   doi: 10.32614/CRAN.package.knitr
 - type: software
   title: 'lifecycle: Manage the Life Cycle of your Package Functions'
@@ -227,6 +236,7 @@ references:
     given-names: Hadley
     email: hadley@posit.co
     orcid: https://orcid.org/0000-0003-4757-117X
+  year: '2026'
   doi: 10.32614/CRAN.package.lifecycle
 - type: software
   title: 'quarto: R Interface to ''Quarto'' Markdown Publishing System'
@@ -242,6 +252,7 @@ references:
     given-names: Christophe
     email: cderv@posit.co
     orcid: https://orcid.org/0000-0003-4474-2498
+  year: '2026'
   doi: 10.32614/CRAN.package.quarto
 - type: software
   title: 'rmarkdown: Dynamic Documents for R'
@@ -284,6 +295,7 @@ references:
     given-names: Richard
     email: rich@posit.co
     orcid: https://orcid.org/0000-0003-3925-190X
+  year: '2026'
   doi: 10.32614/CRAN.package.rmarkdown
 - type: software
   title: 'testthat: Unit Testing for R'
@@ -294,6 +306,7 @@ references:
   - family-names: Wickham
     given-names: Hadley
     email: hadley@posit.co
+  year: '2026'
   doi: 10.32614/CRAN.package.testthat
   version: '>= 3.3.0'
 - type: software
@@ -318,6 +331,7 @@ references:
     given-names: Andy
     email: andy.teucher@posit.co
     orcid: https://orcid.org/0000-0002-7840-692X
+  year: '2026'
   doi: 10.32614/CRAN.package.usethis
 - type: software
   title: 'withr: Run Code ''With'' Temporarily Modified Global State'
@@ -341,5 +355,6 @@ references:
     email: hadley@posit.co
   - family-names: Chang
     given-names: Winston
+  year: '2026'
   doi: 10.32614/CRAN.package.withr
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -102,12 +102,10 @@ references:
     name: R Foundation for Statistical Computing
     website: https://ror.org/05qewa988
     address: Vienna, Austria
-  year: '2026'
   doi: 10.32614/R.manuals
   version: '>= 4.1.0'
 - type: software
-  title: cli
-  abstract: 'cli: Helpers for Developing Command Line Interfaces'
+  title: 'cli: Helpers for Developing Command Line Interfaces'
   notes: Imports
   url: https://cli.r-lib.org
   repository: https://CRAN.R-project.org/package=cli
@@ -115,12 +113,10 @@ references:
   - family-names: Csárdi
     given-names: Gábor
     email: gabor@posit.co
-  year: '2026'
   doi: 10.32614/CRAN.package.cli
   version: '>= 2.0.0'
 - type: software
-  title: desc
-  abstract: 'desc: Manipulate DESCRIPTION Files'
+  title: 'desc: Manipulate DESCRIPTION Files'
   notes: Imports
   url: https://desc.r-lib.org/
   repository: https://CRAN.R-project.org/package=desc
@@ -133,12 +129,10 @@ references:
   - family-names: Hester
     given-names: Jim
     email: james.f.hester@gmail.com
-  year: '2026'
   doi: 10.32614/CRAN.package.desc
   version: '>= 1.3.0'
 - type: software
-  title: jsonlite
-  abstract: 'jsonlite: A Simple and Robust JSON Parser and Generator for R'
+  title: 'jsonlite: A Simple and Robust JSON Parser and Generator for R'
   notes: Imports
   url: https://jeroen.r-universe.dev/jsonlite
   repository: https://CRAN.R-project.org/package=jsonlite
@@ -147,12 +141,10 @@ references:
     given-names: Jeroen
     email: jeroenooms@gmail.com
     orcid: https://orcid.org/0000-0002-4035-0289
-  year: '2026'
   doi: 10.32614/CRAN.package.jsonlite
   version: '>= 1.7.2'
 - type: software
-  title: jsonvalidate
-  abstract: 'jsonvalidate: Validate ''JSON'' Schema'
+  title: 'jsonvalidate: Validate ''JSON'' Schema'
   notes: Imports
   url: https://docs.ropensci.org/jsonvalidate/
   repository: https://CRAN.R-project.org/package=jsonvalidate
@@ -166,12 +158,10 @@ references:
     given-names: Mathias
   - family-names: Poberezkin
     given-names: Evgeny
-  year: '2026'
   doi: 10.32614/CRAN.package.jsonvalidate
   version: '>= 1.1.0'
 - type: software
-  title: tools
-  abstract: 'R: A Language and Environment for Statistical Computing'
+  title: 'R: A Language and Environment for Statistical Computing'
   notes: Imports
   authors:
   - name: R Core Team
@@ -180,24 +170,9 @@ references:
     name: R Foundation for Statistical Computing
     website: https://ror.org/05qewa988
     address: Vienna, Austria
-  year: '2026'
   doi: 10.32614/R.manuals
 - type: software
-  title: utils
-  abstract: 'R: A Language and Environment for Statistical Computing'
-  notes: Imports
-  authors:
-  - name: R Core Team
-    website: https://ror.org/02zz1nj61
-  institution:
-    name: R Foundation for Statistical Computing
-    website: https://ror.org/05qewa988
-    address: Vienna, Austria
-  year: '2026'
-  doi: 10.32614/R.manuals
-- type: software
-  title: yaml
-  abstract: 'yaml: Methods to Convert R Data to YAML and Back'
+  title: 'yaml: Methods to Convert R Data to YAML and Back'
   notes: Imports
   url: https://yaml.r-lib.org
   repository: https://CRAN.R-project.org/package=yaml
@@ -206,12 +181,10 @@ references:
     given-names: Jeremy
   - family-names: Simonov
     given-names: Kirill
-  year: '2026'
   doi: 10.32614/CRAN.package.yaml
   version: '>= 2.2.1'
 - type: software
-  title: bibtex
-  abstract: 'bibtex: Bibtex Parser'
+  title: 'bibtex: Bibtex Parser'
   notes: Suggests
   url: https://docs.ropensci.org/bibtex/
   repository: https://CRAN.R-project.org/package=bibtex
@@ -228,12 +201,10 @@ references:
     given-names: James Joseph
     email: balamut2@illinois.edu
     orcid: https://orcid.org/0000-0003-2826-8458
-  year: '2026'
   doi: 10.32614/CRAN.package.bibtex
   version: '>= 0.5.0'
 - type: software
-  title: knitr
-  abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
+  title: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
   notes: Suggests
   url: https://yihui.org/knitr/
   repository: https://CRAN.R-project.org/package=knitr
@@ -242,11 +213,9 @@ references:
     given-names: Yihui
     email: xie@yihui.name
     orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2026'
   doi: 10.32614/CRAN.package.knitr
 - type: software
-  title: lifecycle
-  abstract: 'lifecycle: Manage the Life Cycle of your Package Functions'
+  title: 'lifecycle: Manage the Life Cycle of your Package Functions'
   notes: Suggests
   url: https://lifecycle.r-lib.org/
   repository: https://CRAN.R-project.org/package=lifecycle
@@ -258,11 +227,9 @@ references:
     given-names: Hadley
     email: hadley@posit.co
     orcid: https://orcid.org/0000-0003-4757-117X
-  year: '2026'
   doi: 10.32614/CRAN.package.lifecycle
 - type: software
-  title: quarto
-  abstract: 'quarto: R Interface to ''Quarto'' Markdown Publishing System'
+  title: 'quarto: R Interface to ''Quarto'' Markdown Publishing System'
   notes: Suggests
   url: https://quarto-dev.github.io/quarto-r/
   repository: https://CRAN.R-project.org/package=quarto
@@ -275,11 +242,9 @@ references:
     given-names: Christophe
     email: cderv@posit.co
     orcid: https://orcid.org/0000-0003-4474-2498
-  year: '2026'
   doi: 10.32614/CRAN.package.quarto
 - type: software
-  title: rmarkdown
-  abstract: 'rmarkdown: Dynamic Documents for R'
+  title: 'rmarkdown: Dynamic Documents for R'
   notes: Suggests
   url: https://pkgs.rstudio.com/rmarkdown/
   repository: https://CRAN.R-project.org/package=rmarkdown
@@ -319,11 +284,9 @@ references:
     given-names: Richard
     email: rich@posit.co
     orcid: https://orcid.org/0000-0003-3925-190X
-  year: '2026'
   doi: 10.32614/CRAN.package.rmarkdown
 - type: software
-  title: testthat
-  abstract: 'testthat: Unit Testing for R'
+  title: 'testthat: Unit Testing for R'
   notes: Suggests
   url: https://testthat.r-lib.org
   repository: https://CRAN.R-project.org/package=testthat
@@ -331,12 +294,10 @@ references:
   - family-names: Wickham
     given-names: Hadley
     email: hadley@posit.co
-  year: '2026'
   doi: 10.32614/CRAN.package.testthat
   version: '>= 3.3.0'
 - type: software
-  title: usethis
-  abstract: 'usethis: Automate Package and Project Setup'
+  title: 'usethis: Automate Package and Project Setup'
   notes: Suggests
   url: https://usethis.r-lib.org
   repository: https://CRAN.R-project.org/package=usethis
@@ -357,11 +318,9 @@ references:
     given-names: Andy
     email: andy.teucher@posit.co
     orcid: https://orcid.org/0000-0002-7840-692X
-  year: '2026'
   doi: 10.32614/CRAN.package.usethis
 - type: software
-  title: withr
-  abstract: 'withr: Run Code ''With'' Temporarily Modified Global State'
+  title: 'withr: Run Code ''With'' Temporarily Modified Global State'
   notes: Suggests
   url: https://withr.r-lib.org
   repository: https://CRAN.R-project.org/package=withr
@@ -382,6 +341,5 @@ references:
     email: hadley@posit.co
   - family-names: Chang
     given-names: Winston
-  year: '2026'
   doi: 10.32614/CRAN.package.withr
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,11 @@
 - `as_cff.bibentry()` now selects the first `issn` of each `bibentry()`.
 - `cff_create()` no longer creates duplicate identifiers when adding inferred
   CRAN metadata.
+- `cff_create()` now adds inferred CRAN DOIs only to packages available from
+  CRAN and preserves dependency titles, abstracts and years as extracted.
+- `cff_read_citation()` now makes all `DESCRIPTION` fields available to
+  `CITATION` files and no longer replaces package metadata with metadata from
+  the **base** package when reading fails.
 
 # cffr 1.4.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,9 @@
 - `cff_create()` no longer creates duplicate identifiers when adding inferred
   CRAN metadata.
 - `cff_create()` now adds inferred CRAN DOIs only to packages available from
-  CRAN, preserves dependency titles and abstracts as extracted and no longer
-  substitutes the current year when a dependency release date is unavailable
-  (#114).
+  CRAN and preserves dependency titles, abstracts and citation years as
+  extracted. A dependency release date takes precedence over its citation year
+  when available (#114).
 - `cff_read_citation()` now makes all `DESCRIPTION` fields available to
   `CITATION` files and no longer replaces package metadata with metadata from
   the **base** package when reading fails (#114).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,9 @@
 # cffr (development version)
 
 - `as_cff.bibentry()` now selects the first `issn` of each `bibentry()`.
-- `cff_create()` no longer creates duplicate identifiers when adding inferred
-  CRAN metadata.
-- `cff_create()` now adds inferred CRAN DOIs only to packages available from
-  CRAN and preserves dependency titles, abstracts and citation years as
-  extracted. A dependency release date takes precedence over its citation year
-  when available (#114).
-- `cff_read_citation()` now makes all `DESCRIPTION` fields available to
-  `CITATION` files and no longer replaces package metadata with metadata from
-  the **base** package when reading fails (#114).
+- `cff_create()` no longer creates duplicate identifiers when merging inferred CRAN metadata with `CITATION` metadata.
+- `cff_create()` now adds inferred CRAN DOIs only to packages available from CRAN. Dependency references retain extracted titles, abstracts, authors and citation years while adding their declared scope and version constraint, plus URLs and repository information from installed package metadata; a release date takes precedence over a citation year when available (#114).
+- `cff_read_citation()` now makes every field supplied in `meta`, including custom `DESCRIPTION` fields, available to `CITATION` files and no longer retries with metadata from the **base** package when reading fails (#114).
 
 # cffr 1.4.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,12 @@
 - `cff_create()` no longer creates duplicate identifiers when adding inferred
   CRAN metadata.
 - `cff_create()` now adds inferred CRAN DOIs only to packages available from
-  CRAN and preserves dependency titles, abstracts and years as extracted.
+  CRAN, preserves dependency titles and abstracts as extracted and no longer
+  substitutes the current year when a dependency release date is unavailable
+  (#114).
 - `cff_read_citation()` now makes all `DESCRIPTION` fields available to
   `CITATION` files and no longer replaces package metadata with metadata from
-  the **base** package when reading fails.
+  the **base** package when reading fails (#114).
 
 # cffr 1.4.2
 

--- a/R/cff-create.R
+++ b/R/cff-create.R
@@ -21,8 +21,8 @@
 #'   generated metadata.
 #' @param gh_keywords A logical value. If `TRUE` and the package is hosted on
 #'   GitHub, add the repository topics as keywords.
-#' @param dependencies A logical value. If `TRUE`, add the package dependencies
-#'   to the `references` CFF key.
+#' @param dependencies A logical value. If `TRUE`, add installed package
+#'   dependencies to the `references` CFF key. See **Details**.
 #' @param authors_roles Roles to be considered as authors of the package when
 #'   generating the `CITATION.cff` file. See **Details**.
 #'
@@ -32,6 +32,21 @@
 #' If `x` is a path to a `DESCRIPTION` file or if `inst/CITATION` is not
 #' present in your package, \CRANpkg{cffr} auto-generates a
 #' `preferred-citation` key using the information provided in that file.
+#'
+#' When `inst/CITATION` is present, every field from the package's
+#' `DESCRIPTION`, including custom fields, is made available to that file
+#' through its `meta` object. If the file cannot be evaluated with those
+#' metadata, `cff_create()` does not retry with metadata from another package.
+#'
+#' When `dependencies = TRUE`, `cff_create()` starts from the first reference
+#' returned by [utils::citation()] for each installed dependency. Citation
+#' fields such as title, abstract, authors and year are preserved. Each
+#' reference is adapted to the CFF software-reference type and enriched with
+#' the dependency scope and version constraint from the source `DESCRIPTION`,
+#' URLs and repository information from the installed dependency's
+#' `DESCRIPTION` and the canonical CRAN DOI only when the dependency is
+#' available from CRAN. A release date, when present, determines the year;
+#' otherwise the citation year is retained.
 #'
 #' By default, only persons whose role in the `DESCRIPTION` file of the package
 #' is author (`"aut"`) or maintainer (`"cre"`) are considered package authors.

--- a/R/cff-read.R
+++ b/R/cff-read.R
@@ -216,20 +216,15 @@ cff_read_citation <- function(path, meta = NULL, ...) {
   new_meta <- clean_package_meta(meta)
   the_cit <- try(cff_read_citation_file(path, meta = new_meta), silent = TRUE)
 
-  # If there is an error, try again.
+  # If there is an error, return no citation.
   if (inherits(the_cit, "try-error")) {
-    cli::cli_alert_warning(paste0(
-      "Could not read {.file {path}} with the provided {.arg meta}. ",
-      'Trying {.code utils::packageDescription("base")}.'
-    ))
-    new_meta <- packageDescription("base")
-    the_cit <- try(cff_read_citation_file(path, meta = new_meta), silent = TRUE)
-    if (inherits(the_cit, "try-error")) {
-      cli::cli_alert_danger(
-        "Cannot read {.file {path}}. Returning {.code NULL}."
+    cli::cli_alert_danger(
+      paste0(
+        "Cannot read {.file {path}} with the provided {.arg meta}. ",
+        "Returning {.code NULL}."
       )
-      return(NULL)
-    }
+    )
+    return(NULL)
   }
   tocff <- as_cff(the_cit)
 

--- a/R/cff-read.R
+++ b/R/cff-read.R
@@ -218,12 +218,10 @@ cff_read_citation <- function(path, meta = NULL, ...) {
 
   # If there is an error, return no citation.
   if (inherits(the_cit, "try-error")) {
-    cli::cli_alert_danger(
-      paste0(
-        "Cannot read {.file {path}} with the provided {.arg meta}. ",
-        "Returning {.code NULL}."
-      )
-    )
+    cli::cli_alert_danger(paste0(
+      "Cannot read {.file {path}} with the provided {.arg meta}. ",
+      "Returning {.code NULL}."
+    ))
     return(NULL)
   }
   tocff <- as_cff(the_cit)

--- a/R/cff-read.R
+++ b/R/cff-read.R
@@ -17,7 +17,7 @@
 #'
 #' @param path A path to a file.
 #' @param encoding Encoding to be assumed for `path`. See [base::readLines()].
-#' @param meta A list of package metadata as obtained by
+#' @param meta A package metadata object as obtained by
 #'   [utils::packageDescription()] or `NULL` (the default). See **Details**.
 #' @param ... Arguments passed to other functions, for example to
 #'   [yaml::read_yaml()] or [bibtex::read.bib()].
@@ -27,11 +27,13 @@
 #' @return
 #' - `cff_read_cff_citation()` and `cff_read_description()` return an object
 #'   with class `cff`.
-#' - `cff_read_citation()` and `cff_read_bib()` return an object of classes
+#' - `cff_read_bib()` returns an object of classes
 #'   [`cff_ref_lst, cff`][cff_ref_lst] as defined by the
 #'   `definitions.reference` specified in the following guide:
 #' ```{r child = "man/chunks/schema-guide.Rmd"}
 #' ```
+#' - `cff_read_citation()` returns the same classes as `cff_read_bib()`, or
+#'   `NULL` when the file cannot be evaluated.
 #'
 #' Learn more about the \CRANpkg{cffr} class system in [cff_class].
 #'
@@ -42,8 +44,13 @@
 #'
 #' Section 1.9 CITATION files of *Writing R Extensions* (R Core Team 2026)
 #' specifies how to create dynamic `CITATION` files using a `meta` object.
-#' Therefore, the `meta` argument in [cff_read_citation()] may be needed to
-#' read some files correctly.
+#' [cff_read_citation()] makes every field supplied in `meta`, including custom
+#' `DESCRIPTION` fields, available to the `CITATION` file. When `cff_create()`
+#' reads a package `CITATION` file, it constructs `meta` from all fields in that
+#' package's `DESCRIPTION`. With `meta = NULL`, only default encoding metadata
+#' is supplied. If the file cannot be evaluated with those metadata,
+#' `cff_read_citation()` returns `NULL`; it does not substitute metadata from
+#' another package.
 #'
 #' @references
 #' R Core Team (2026). *Writing R Extensions*.

--- a/R/cff-write.R
+++ b/R/cff-write.R
@@ -28,7 +28,7 @@
 #' primarily for its side effect of writing a `CITATION.cff` file.
 #'
 #' @details
-#' For details of `authors_roles`, see [cff_create()].
+#' For details of `authors_roles` and dependency extraction, see [cff_create()].
 #'
 #' The `x` argument identifies the metadata source. It does not determine the
 #' output directory. This allows you to create a `CITATION.cff` from a package

--- a/R/utils-cff-read.R
+++ b/R/utils-cff-read.R
@@ -384,11 +384,15 @@ get_desc_sha <- function(pkg) {
 }
 
 get_desc_doi <- function(pkg) {
-  pkg <- pkg$get("Package")
-  if (is.null(search_on_repos(pkg))) {
+  package <- pkg$get("Package")
+  repository <- clean_str(pkg$get("Repository"))
+  on_cran <- identical(repository, "CRAN") ||
+    identical(search_on_repos(package), cran_package_url(package))
+
+  if (!on_cran) {
     return(NULL)
   }
 
-  doi <- paste0("10.32614/CRAN.package.", pkg)
+  doi <- paste0("10.32614/CRAN.package.", package)
   clean_str(doi)
 }

--- a/R/utils-create.R
+++ b/R/utils-create.R
@@ -213,7 +213,7 @@ cff_dependency_year <- function(mod) {
   date_rel <- mod[["date-released"]]
 
   if (is.null(date_rel)) {
-    return(NULL)
+    return(mod[["year"]])
   }
 
   format(as.Date(date_rel), "%Y")

--- a/R/utils-create.R
+++ b/R/utils-create.R
@@ -165,7 +165,6 @@ cff_dependency_reference <- function(dep) {
 cff_dependency_citation <- function(package) {
   if (package == "R") {
     mod <- as_cff(cff_citation())[[1]]
-    mod$year <- format(Sys.Date(), "%Y")
     return(mod)
   }
 
@@ -174,10 +173,6 @@ cff_dependency_citation <- function(package) {
   if (inherits(mod, "try-error")) {
     return(NULL)
   }
-
-  # Simplify the `cff` object to avoid cluttering the output.
-  mod$abstract <- mod$title
-  mod$title <- package
 
   if (is_cran_dependency(package)) {
     mod$doi <- paste0("10.32614/CRAN.package.", package)
@@ -191,10 +186,13 @@ cff_citation <- function(...) {
 }
 
 is_cran_dependency <- function(package) {
-  avail <- get_avail_on_init()
   base_packages <- rownames(installed.packages(priority = "base"))
+  repository <- search_on_repos(package)
 
-  all(package %in% avail$Package, !package %in% base_packages)
+  all(
+    !package %in% base_packages,
+    identical(repository, cran_package_url(package))
+  )
 }
 
 cff_dependency_desc_fields <- function(mod, package) {
@@ -215,7 +213,7 @@ cff_dependency_year <- function(mod) {
   date_rel <- mod[["date-released"]]
 
   if (is.null(date_rel)) {
-    return(format(Sys.Date(), "%Y"))
+    return(NULL)
   }
 
   format(as.Date(date_rel), "%Y")

--- a/R/utils.R
+++ b/R/utils.R
@@ -286,7 +286,7 @@ clean_package_meta <- function(meta) {
   pkg <- desc::desc(tmp)
   pkg$coerce_authors_at_r()
   # Extract package data.
-  meta <- pkg$get(desc::cran_valid_fields)
+  meta <- pkg$get(pkg$fields())
 
   # Clean missing values and drop empty fields.
   meta <- drop_null(lapply(meta, clean_str))
@@ -308,7 +308,7 @@ desc_to_meta <- function(x) {
   my_meta$coerce_authors_at_r()
 
   # Convert to a list.
-  my_meta_l <- my_meta$get(desc::cran_valid_fields)
+  my_meta_l <- my_meta$get(my_meta$fields())
   my_meta_l <- as.list(my_meta_l)
   v_nas <- vapply(my_meta_l, is.na, logical(1))
   my_meta_l <- my_meta_l[!v_nas]

--- a/README.md
+++ b/README.md
@@ -238,9 +238,8 @@ test <- cff_create("knitr")
       doi: 10.32614/R.manuals
       version: '>= 3.6.0'
     - type: software
-      title: evaluate
-      abstract: 'evaluate: Parsing and Evaluation Tools that Provide More Details than
-        the Default'
+      title: 'evaluate: Parsing and Evaluation Tools that Provide More Details than the
+        Default'
       notes: Imports
       url: https://evaluate.r-lib.org/
       repository: https://CRAN.R-project.org/package=evaluate
@@ -251,12 +250,11 @@ test <- cff_create("knitr")
       - family-names: Xie
         given-names: Yihui
         orcid: https://orcid.org/0000-0003-0645-5666
-      year: '2026'
+      year: '2025'
       doi: 10.32614/CRAN.package.evaluate
       version: '>= 0.15'
     - type: software
-      title: highr
-      abstract: 'highr: Syntax Highlighting for R Source Code'
+      title: 'highr: Syntax Highlighting for R Source Code'
       notes: Imports
       url: https://github.com/yihui/highr
       repository: https://CRAN.R-project.org/package=highr
@@ -271,8 +269,7 @@ test <- cff_create("knitr")
       doi: 10.32614/CRAN.package.highr
       version: '>= 0.11'
     - type: software
-      title: methods
-      abstract: 'R: A Language and Environment for Statistical Computing'
+      title: 'R: A Language and Environment for Statistical Computing'
       notes: Imports
       authors:
       - name: R Core Team
@@ -284,21 +281,7 @@ test <- cff_create("knitr")
       year: '2026'
       doi: 10.32614/R.manuals
     - type: software
-      title: tools
-      abstract: 'R: A Language and Environment for Statistical Computing'
-      notes: Imports
-      authors:
-      - name: R Core Team
-        website: https://ror.org/02zz1nj61
-      institution:
-        name: R Foundation for Statistical Computing
-        website: https://ror.org/05qewa988
-        address: Vienna, Austria
-      year: '2026'
-      doi: 10.32614/R.manuals
-    - type: software
-      title: xfun
-      abstract: 'xfun: Supporting Functions for Packages Maintained by ''Yihui Xie'''
+      title: 'xfun: Supporting Functions for Packages Maintained by ''Yihui Xie'''
       notes: Imports
       url: https://github.com/yihui/xfun
       repository: https://CRAN.R-project.org/package=xfun
@@ -311,8 +294,7 @@ test <- cff_create("knitr")
       doi: 10.32614/CRAN.package.xfun
       version: '>= 0.52'
     - type: software
-      title: yaml
-      abstract: 'yaml: Methods to Convert R Data to YAML and Back'
+      title: 'yaml: Methods to Convert R Data to YAML and Back'
       notes: Imports
       url: https://yaml.r-lib.org
       repository: https://CRAN.R-project.org/package=yaml
@@ -321,12 +303,11 @@ test <- cff_create("knitr")
         given-names: Jeremy
       - family-names: Simonov
         given-names: Kirill
-      year: '2026'
+      year: '2025'
       doi: 10.32614/CRAN.package.yaml
       version: '>= 2.1.19'
     - type: software
-      title: bslib
-      abstract: 'bslib: Custom ''Bootstrap'' ''Sass'' Themes for ''shiny'' and ''rmarkdown'''
+      title: 'bslib: Custom ''Bootstrap'' ''Sass'' Themes for ''shiny'' and ''rmarkdown'''
       notes: Suggests
       url: https://rstudio.github.io/bslib/
       repository: https://CRAN.R-project.org/package=bslib
@@ -345,8 +326,7 @@ test <- cff_create("knitr")
       year: '2026'
       doi: 10.32614/CRAN.package.bslib
     - type: software
-      title: DBI
-      abstract: 'DBI: R Database Interface'
+      title: 'DBI: R Database Interface'
       notes: Suggests
       url: https://dbi.r-dbi.org
       repository: https://CRAN.R-project.org/package=DBI
@@ -362,8 +342,7 @@ test <- cff_create("knitr")
       doi: 10.32614/CRAN.package.DBI
       version: '>= 0.4-1'
     - type: software
-      title: digest
-      abstract: 'digest: Create Compact Hash Digests of R Objects'
+      title: 'digest: Create Compact Hash Digests of R Objects'
       notes: Suggests
       url: https://eddelbuettel.github.io/digest/
       repository: https://CRAN.R-project.org/package=digest
@@ -372,11 +351,10 @@ test <- cff_create("knitr")
         given-names: Dirk
         email: edd@debian.org
         orcid: https://orcid.org/0000-0001-6419-907X
-      year: '2026'
+      year: '2025'
       doi: 10.32614/CRAN.package.digest
     - type: software
-      title: gifski
-      abstract: 'gifski: Highest Quality GIF Encoder'
+      title: 'gifski: Highest Quality GIF Encoder'
       notes: Suggests
       url: https://r-rust.r-universe.dev/gifski
       repository: https://CRAN.R-project.org/package=gifski
@@ -387,11 +365,10 @@ test <- cff_create("knitr")
         orcid: https://orcid.org/0000-0002-4035-0289
       - name: Kornel Lesiński
       - name: Authors of the dependency Rust crates
-      year: '2026'
+      year: '2025'
       doi: 10.32614/CRAN.package.gifski
     - type: software
-      title: htmlwidgets
-      abstract: 'htmlwidgets: HTML Widgets for R'
+      title: 'htmlwidgets: HTML Widgets for R'
       notes: Suggests
       url: https://github.com/ramnathv/htmlwidgets
       repository: https://CRAN.R-project.org/package=htmlwidgets
@@ -411,12 +388,11 @@ test <- cff_create("knitr")
         orcid: https://orcid.org/0000-0002-4958-2844
       - family-names: Russell
         given-names: Kenton
-      year: '2026'
+      year: '2023'
       doi: 10.32614/CRAN.package.htmlwidgets
       version: '>= 0.7'
     - type: software
-      title: jpeg
-      abstract: 'jpeg: Read and write JPEG images'
+      title: 'jpeg: Read and write JPEG images'
       notes: Suggests
       url: https://www.rforge.net/jpeg/
       repository: https://CRAN.R-project.org/package=jpeg
@@ -425,11 +401,10 @@ test <- cff_create("knitr")
         given-names: Simon
         email: Simon.Urbanek@r-project.org
         orcid: https://orcid.org/0000-0003-2297-1732
-      year: '2026'
+      year: '2025'
       doi: 10.32614/CRAN.package.jpeg
     - type: software
-      title: magick
-      abstract: 'magick: Advanced Graphics and Image-Processing in R'
+      title: 'magick: Advanced Graphics and Image-Processing in R'
       notes: Suggests
       url: https://docs.ropensci.org/magick/
       repository: https://CRAN.R-project.org/package=magick
@@ -441,8 +416,7 @@ test <- cff_create("knitr")
       year: '2026'
       doi: 10.32614/CRAN.package.magick
     - type: software
-      title: litedown
-      abstract: 'litedown: A Lightweight Version of R Markdown'
+      title: 'litedown: A Lightweight Version of R Markdown'
       notes: Suggests
       url: https://github.com/yihui/litedown
       repository: https://CRAN.R-project.org/package=litedown
@@ -454,8 +428,7 @@ test <- cff_create("knitr")
       year: '2026'
       doi: 10.32614/CRAN.package.litedown
     - type: software
-      title: markdown
-      abstract: 'markdown: Render Markdown with ''commonmark'''
+      title: 'markdown: Render Markdown with ''commonmark'''
       notes: Suggests
       url: https://github.com/rstudio/markdown
       repository: https://CRAN.R-project.org/package=markdown
@@ -468,12 +441,11 @@ test <- cff_create("knitr")
         given-names: JJ
       - family-names: Horner
         given-names: Jeffrey
-      year: '2026'
+      year: '2025'
       doi: 10.32614/CRAN.package.markdown
       version: '>= 1.3'
     - type: software
-      title: otel
-      abstract: 'otel: OpenTelemetry R API'
+      title: 'otel: OpenTelemetry R API'
       notes: Suggests
       url: https://otel.r-lib.org
       repository: https://CRAN.R-project.org/package=otel
@@ -481,11 +453,10 @@ test <- cff_create("knitr")
       - family-names: Csárdi
         given-names: Gábor
         email: csardi.gabor@gmail.com
-      year: '2026'
+      year: '2025'
       doi: 10.32614/CRAN.package.otel
     - type: software
-      title: png
-      abstract: 'png: Read and write PNG images'
+      title: 'png: Read and write PNG images'
       notes: Suggests
       url: https://www.rforge.net/png/
       repository: https://CRAN.R-project.org/package=png
@@ -497,8 +468,7 @@ test <- cff_create("knitr")
       year: '2026'
       doi: 10.32614/CRAN.package.png
     - type: software
-      title: ragg
-      abstract: 'ragg: Graphic Devices Based on AGG'
+      title: 'ragg: Graphic Devices Based on AGG'
       notes: Suggests
       url: https://ragg.r-lib.org
       repository: https://CRAN.R-project.org/package=ragg
@@ -512,8 +482,7 @@ test <- cff_create("knitr")
       year: '2026'
       doi: 10.32614/CRAN.package.ragg
     - type: software
-      title: rlang
-      abstract: 'rlang: Functions for Base Types and Core R and ''Tidyverse'' Features'
+      title: 'rlang: Functions for Base Types and Core R and ''Tidyverse'' Features'
       notes: Suggests
       url: https://rlang.r-lib.org
       repository: https://CRAN.R-project.org/package=rlang
@@ -527,8 +496,7 @@ test <- cff_create("knitr")
       year: '2026'
       doi: 10.32614/CRAN.package.rlang
     - type: software
-      title: rmarkdown
-      abstract: 'rmarkdown: Dynamic Documents for R'
+      title: 'rmarkdown: Dynamic Documents for R'
       notes: Suggests
       url: https://pkgs.rstudio.com/rmarkdown/
       repository: https://CRAN.R-project.org/package=rmarkdown
@@ -571,8 +539,7 @@ test <- cff_create("knitr")
       year: '2026'
       doi: 10.32614/CRAN.package.rmarkdown
     - type: software
-      title: sass
-      abstract: 'sass: Syntactically Awesome Style Sheets (''Sass'')'
+      title: 'sass: Syntactically Awesome Style Sheets (''Sass'')'
       notes: Suggests
       url: https://rstudio.github.io/sass/
       repository: https://CRAN.R-project.org/package=sass
@@ -595,11 +562,10 @@ test <- cff_create("knitr")
         given-names: Carson
         email: carson@rstudio.com
         orcid: https://orcid.org/0000-0002-4958-2844
-      year: '2026'
+      year: '2025'
       doi: 10.32614/CRAN.package.sass
     - type: software
-      title: showtext
-      abstract: 'showtext: Using Fonts More Easily in R Graphs'
+      title: 'showtext: Using Fonts More Easily in R Graphs'
       notes: Suggests
       url: https://github.com/yixuan/showtext
       repository: https://CRAN.R-project.org/package=showtext
@@ -610,8 +576,7 @@ test <- cff_create("knitr")
       year: '2026'
       doi: 10.32614/CRAN.package.showtext
     - type: software
-      title: styler
-      abstract: 'styler: Non-Invasive Pretty Printing of R Code'
+      title: 'styler: Non-Invasive Pretty Printing of R Code'
       notes: Suggests
       url: https://styler.r-lib.org
       repository: https://CRAN.R-project.org/package=styler
@@ -627,12 +592,11 @@ test <- cff_create("knitr")
         given-names: Indrajeet
         email: patilindrajeet.science@gmail.com
         orcid: https://orcid.org/0000-0003-1995-6531
-      year: '2026'
+      year: '2025'
       doi: 10.32614/CRAN.package.styler
       version: '>= 1.2.0'
     - type: software
-      title: tibble
-      abstract: 'tibble: Simple Data Frames'
+      title: 'tibble: Simple Data Frames'
       notes: Suggests
       url: https://tibble.tidyverse.org/
       repository: https://CRAN.R-project.org/package=tibble
@@ -647,8 +611,7 @@ test <- cff_create("knitr")
       year: '2026'
       doi: 10.32614/CRAN.package.tibble
     - type: software
-      title: tinytex
-      abstract: 'tinytex: Helper Functions to Install and Maintain TeX Live, and Compile
+      title: 'tinytex: Helper Functions to Install and Maintain TeX Live, and Compile
         LaTeX Documents'
       notes: Suggests
       url: https://github.com/rstudio/tinytex
@@ -662,8 +625,7 @@ test <- cff_create("knitr")
       doi: 10.32614/CRAN.package.tinytex
       version: '>= 0.56'
     - type: software
-      title: rstudioapi
-      abstract: 'rstudioapi: Safely Access the RStudio API'
+      title: 'rstudioapi: Safely Access the RStudio API'
       notes: Suggests
       url: https://rstudio.github.io/rstudioapi/
       repository: https://CRAN.R-project.org/package=rstudioapi

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ from **R** package metadata.
 its `CITATION` file, if present. **cffr** works best if your package
 passes `R CMD check` or `devtools::check()`.
 
-As of 2026-08-29 there are at least 22 repositories on GitHub using
+As of 2026-08-29 there are at least 24 repositories on GitHub using
 **cffr**. [Browse the search
 results](https://github.com/search?q=cffr%20path%3A**%2FCITATION.cff&type=code).
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -234,7 +234,7 @@
   },
   "isPartOf": "https://ropensci.org",
   "keywords": ["attribution", "citation", "credit", "citation-files", "cff", "metadata", "citation-file-format", "cran", "r", "r-package", "ropensci", "rstats", "r-cran"],
-  "fileSize": "1006.938KB",
+  "fileSize": "1010.491KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",

--- a/codemeta.json
+++ b/codemeta.json
@@ -234,7 +234,7 @@
   },
   "isPartOf": "https://ropensci.org",
   "keywords": ["attribution", "citation", "credit", "citation-files", "cff", "metadata", "citation-file-format", "cran", "r", "r-package", "ropensci", "rstats", "r-cran"],
-  "fileSize": "1003.932KB",
+  "fileSize": "1006.938KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",

--- a/man/cff_create.Rd
+++ b/man/cff_create.Rd
@@ -33,8 +33,8 @@ generated metadata.}
 \item{gh_keywords}{A logical value. If \code{TRUE} and the package is hosted on
 GitHub, add the repository topics as keywords.}
 
-\item{dependencies}{A logical value. If \code{TRUE}, add the package dependencies
-to the \code{references} CFF key.}
+\item{dependencies}{A logical value. If \code{TRUE}, add installed package
+dependencies to the \code{references} CFF key. See \strong{Details}.}
 
 \item{authors_roles}{Roles to be considered as authors of the package when
 generating the \code{CITATION.cff} file. See \strong{Details}.}
@@ -54,6 +54,21 @@ This function performs most metadata extraction and conversion in
 If \code{x} is a path to a \code{DESCRIPTION} file or if \code{inst/CITATION} is not
 present in your package, \CRANpkg{cffr} auto-generates a
 \code{preferred-citation} key using the information provided in that file.
+
+When \code{inst/CITATION} is present, every field from the package's
+\code{DESCRIPTION}, including custom fields, is made available to that file
+through its \code{meta} object. If the file cannot be evaluated with those
+metadata, \code{cff_create()} does not retry with metadata from another package.
+
+When \code{dependencies = TRUE}, \code{cff_create()} starts from the first reference
+returned by \code{\link[utils:citation]{utils::citation()}} for each installed dependency. Citation
+fields such as title, abstract, authors and year are preserved. Each
+reference is adapted to the CFF software-reference type and enriched with
+the dependency scope and version constraint from the source \code{DESCRIPTION},
+URLs and repository information from the installed dependency's
+\code{DESCRIPTION} and the canonical CRAN DOI only when the dependency is
+available from CRAN. A release date, when present, determines the year;
+otherwise the citation year is retained.
 
 By default, only persons whose role in the \code{DESCRIPTION} file of the package
 is author (\code{"aut"}) or maintainer (\code{"cre"}) are considered package authors.

--- a/man/cff_read.Rd
+++ b/man/cff_read.Rd
@@ -40,7 +40,7 @@ GitHub, add the repository topics as keywords.}
 \item{authors_roles}{Roles to be considered as authors of the package when
 generating the \code{CITATION.cff} file. See \strong{Details}.}
 
-\item{meta}{A list of package metadata as obtained by
+\item{meta}{A package metadata object as obtained by
 \code{\link[utils:packageDescription]{utils::packageDescription()}} or \code{NULL} (the default). See \strong{Details}.}
 
 \item{encoding}{Encoding to be assumed for \code{path}. See \code{\link[base:readLines]{base::readLines()}}.}
@@ -49,10 +49,12 @@ generating the \code{CITATION.cff} file. See \strong{Details}.}
 \itemize{
 \item \code{cff_read_cff_citation()} and \code{cff_read_description()} return an object
 with class \code{cff}.
-\item \code{cff_read_citation()} and \code{cff_read_bib()} return an object of classes
+\item \code{cff_read_bib()} returns an object of classes
 \code{\link[=cff_ref_lst]{cff_ref_lst, cff}} as defined by the
 \code{definitions.reference} specified in the following guide:
 \href{https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md}{Citation File Format schema guide}.
+\item \code{cff_read_citation()} returns the same classes as \code{cff_read_bib()}, or
+\code{NULL} when the file cannot be evaluated.
 }
 
 Learn more about the \CRANpkg{cffr} class system in \link{cff_class}.
@@ -82,8 +84,13 @@ For details of \code{cff_read_description()}, see \code{\link[=cff_create]{cff_c
 
 Section 1.9 CITATION files of \emph{Writing R Extensions} (R Core Team 2026)
 specifies how to create dynamic \code{CITATION} files using a \code{meta} object.
-Therefore, the \code{meta} argument in \code{\link[=cff_read_citation]{cff_read_citation()}} may be needed to
-read some files correctly.
+\code{\link[=cff_read_citation]{cff_read_citation()}} makes every field supplied in \code{meta}, including custom
+\code{DESCRIPTION} fields, available to the \code{CITATION} file. When \code{cff_create()}
+reads a package \code{CITATION} file, it constructs \code{meta} from all fields in that
+package's \code{DESCRIPTION}. With \code{meta = NULL}, only default encoding metadata
+is supplied. If the file cannot be evaluated with those metadata,
+\code{cff_read_citation()} returns \code{NULL}; it does not substitute metadata from
+another package.
 }
 }
 \examples{

--- a/man/cff_write.Rd
+++ b/man/cff_write.Rd
@@ -47,8 +47,8 @@ citation (\code{inst/CITATION}) is created or updated relative to the current
 working directory. \strong{No backup copy is created}. For more control, use
 \code{\link[=cff_write_citation]{cff_write_citation()}}.}
 
-\item{dependencies}{A logical value. If \code{TRUE}, add the package dependencies
-to the \code{references} CFF key.}
+\item{dependencies}{A logical value. If \code{TRUE}, add installed package
+dependencies to the \code{references} CFF key. See \strong{Details}.}
 
 \item{validate}{A logical value. If \code{TRUE}, validate the new file with
 \code{\link[=cff_validate]{cff_validate()}}.}
@@ -75,7 +75,7 @@ This function writes a \code{CITATION.cff} file for a given package. It wraps
 YAML-formatted file in one command.
 }
 \details{
-For details of \code{authors_roles}, see \code{\link[=cff_create]{cff_create()}}.
+For details of \code{authors_roles} and dependency extraction, see \code{\link[=cff_create]{cff_create()}}.
 
 The \code{x} argument identifies the metadata source. It does not determine the
 output directory. This allows you to create a \code{CITATION.cff} from a package

--- a/tests/testthat/_snaps/cff-create.md
+++ b/tests/testthat/_snaps/cff-create.md
@@ -68,6 +68,7 @@
       license: GPL-2.0-or-later
       title: 'rgeos: Interface to Geometry Engine - Open Source (''GEOS'')'
       version: 0.5-7
+      doi: 10.32614/CRAN.package.rgeos
       identifiers:
       - type: url
         value: http://rgeos.r-forge.r-project.org/index.html
@@ -162,6 +163,7 @@
       license: GPL-2.0-or-later
       title: 'rgeos: Interface to Geometry Engine - Open Source (''GEOS'')'
       version: 0.5-7
+      doi: 10.32614/CRAN.package.rgeos
       identifiers:
       - type: url
         value: http://rgeos.r-forge.r-project.org/index.html

--- a/tests/testthat/_snaps/cff-read.md
+++ b/tests/testthat/_snaps/cff-read.md
@@ -64,7 +64,7 @@
       notes: 'Publisher: The Open Journal'
       start: '3900'
 
-# cff_read_citation reports fallback attempts
+# cff_read_citation reports read failures
 
     Code
       cff_read_citation("a")

--- a/tests/testthat/_snaps/utils-create.md
+++ b/tests/testthat/_snaps/utils-create.md
@@ -858,6 +858,8 @@
         start: '352'
         end: '357'
       identifiers:
+      - type: doi
+        value: 10.32614/CRAN.package.rgeos
       - type: url
         value: http://rgeos.r-forge.r-project.org/index.html
       references:
@@ -1162,10 +1164,10 @@
     Output
       - title: 'R: A Language and Environment for Statistical Computing'
         url: https://www.R-project.org/
-      - title: cli
+      - title: 'cli: Helpers for Developing Command Line Interfaces'
         url: https://cli.r-lib.org
         repository: https://CRAN.R-project.org/package=cli
-      - title: desc
+      - title: 'desc: Manipulate DESCRIPTION Files'
         url: https://desc.r-lib.org/
         repository: https://CRAN.R-project.org/package=desc
 

--- a/tests/testthat/_snaps/utils-create.md
+++ b/tests/testthat/_snaps/utils-create.md
@@ -1157,17 +1157,14 @@
         url: https://ggplot2.tidyverse.org
       
 
-# dependency helpers select supported package dependencies
+# dependency references preserve citation years
 
     Code
-      print(selected)
+      result
     Output
-      - title: 'R: A Language and Environment for Statistical Computing'
-        url: https://www.R-project.org/
-      - title: 'cli: Helpers for Developing Command Line Interfaces'
-        url: https://cli.r-lib.org
-        repository: https://CRAN.R-project.org/package=cli
-      - title: 'desc: Manipulate DESCRIPTION Files'
-        url: https://desc.r-lib.org/
-        repository: https://CRAN.R-project.org/package=desc
+      type: software
+      title: Dependency title
+      notes: Imports
+      year: '1999'
+      version: '1.0'
 

--- a/tests/testthat/test-cff-create.R
+++ b/tests/testthat/test-cff-create.R
@@ -324,8 +324,11 @@ test_that("cff_create recognizes R-universe repositories", {
   expect_length(a_cff$repository, 1)
 
   expect_s3_class(a_cff, "cff")
-  expect_snapshot(a_cff)
   expect_true(cff_validate(a_cff, verbose = FALSE))
+
+  rvers <- getRversion()
+  skip_if(!grepl("^4.6", rvers), "Snapshot created with R 4.6.*")
+  expect_snapshot(a_cff)
 })
 
 

--- a/tests/testthat/test-cff-read.R
+++ b/tests/testthat/test-cff-read.R
@@ -133,17 +133,23 @@ test_that("DESCRIPTION repository helpers accept fixtures", {
   expect_equal(get_desc_doi(pkg), "10.32614/CRAN.package.fixturepkg")
 })
 
-test_that("DESCRIPTION DOI returns NULL outside known repositories", {
+test_that("DESCRIPTION DOI returns NULL outside CRAN", {
   basic_path <- system.file("examples/DESCRIPTION_basic", package = "cffr")
 
   tmp <- withr::local_tempfile(pattern = "DESCRIPTION_basic")
   file.copy(basic_path, tmp)
 
   pkg <- desc::desc_set("Package", "fixturepkg", file = tmp)
-  empty_avail <- data.frame(Package = character(0), Repository = character(0))
+  avail <- data.frame(
+    Package = "fixturepkg",
+    Repository = "https://fixture.r-universe.dev/src/contrib"
+  )
   withr::local_options(
-    cffr.available_packages = empty_avail,
-    cffr.repos = c(CRAN = "https://cloud.r-project.org/")
+    cffr.available_packages = avail,
+    cffr.repos = c(
+      fixture = "https://fixture.r-universe.dev",
+      CRAN = "https://cloud.r-project.org/"
+    )
   )
 
   expect_null(get_desc_doi(pkg))
@@ -288,7 +294,7 @@ test_that("cff_read_bib reads BibTeX files", {
   expect_identical(f1_2, f2_2)
 })
 
-test_that("cff_read_citation reports fallback attempts", {
+test_that("cff_read_citation reports read failures", {
   expect_snapshot(cff_read_citation("a"), error = TRUE)
 
   f <- system.file("examples/CITATION_basic", package = "cffr")
@@ -302,7 +308,7 @@ test_that("cff_read_citation reports fallback attempts", {
   f <- system.file("examples/CITATION_auto", package = "cffr")
 
   expect_message(s <- cff_read(f), "with the provided")
-  expect_s3_class(s, c("cff_ref_lst", "cff"), exact = TRUE)
+  expect_null(s)
 })
 
 test_that("cff_read reads basic CITATION files", {
@@ -395,6 +401,39 @@ test_that("cff_safe_read_citation reads rmarkdown CITATION files", {
   expect_length(a_cff, 3)
 })
 
+test_that("cff_safe_read_citation preserves additional DESCRIPTION fields", {
+  dir <- withr::local_tempdir()
+  desc_path <- file.path(dir, "DESCRIPTION")
+  cit_path <- file.path(dir, "CITATION")
+  basic_path <- system.file("examples/DESCRIPTION_basic", package = "cffr")
+  file.copy(basic_path, desc_path)
+  desc::desc_set(
+    "Config/Citation-Title",
+    "Title from an additional field",
+    file = desc_path
+  )
+  writeLines(
+    c(
+      "bibentry(",
+      "  bibtype = 'Manual',",
+      "  title = meta[['Config/Citation-Title']],",
+      "  author = person('Jane', 'Doe'),",
+      "  year = '2024'",
+      ")"
+    ),
+    cit_path
+  )
+
+  meta <- desc_to_meta(desc_path)
+  result <- cff_safe_read_citation(desc_path, cit_path)
+
+  expect_identical(
+    unname(meta[["Config/Citation-Title"]]),
+    "Title from an additional field"
+  )
+  expect_identical(result[[1]]$title, "Title from an additional field")
+})
+
 test_that("cff_safe_read_citation returns NULL without readable files", {
   desc_path <- system.file("x", package = "cffr")
   cit_path <- system.file("y", package = "cffr")
@@ -405,10 +444,7 @@ test_that("cff_safe_read_citation returns NULL without readable files", {
 test_that("cff_read returns NULL for corrupt CITATION files", {
   tmp <- withr::local_tempfile(pattern = "CITATION")
   writeLines("I am a bad CITATION", tmp)
-  expect_message(
-    expect_message(anull <- cff_read(tmp), "Could not read"),
-    "Cannot read"
-  )
+  expect_message(anull <- cff_read(tmp), "Cannot read")
   expect_null(anull)
 
   # Internal
@@ -418,17 +454,14 @@ test_that("cff_read returns NULL for corrupt CITATION files", {
   expect_null(anull)
 })
 
-test_that("cff_read_citation returns NULL when both read attempts fail", {
+test_that("cff_read_citation returns NULL when reading fails", {
   tmp <- withr::local_tempfile(pattern = "CITATION")
   writeLines("citEntry(entry = 'Manual')", tmp)
   local_mocked_bindings(cff_read_citation_file = function(...) {
     stop("read failed", call. = FALSE)
   })
 
-  expect_message(
-    expect_message(anull <- cff_read_citation(tmp), "Could not read"),
-    "Cannot read"
-  )
+  expect_message(anull <- cff_read_citation(tmp), "Cannot read")
   expect_null(anull)
 })
 

--- a/tests/testthat/test-utils-create.R
+++ b/tests/testthat/test-utils-create.R
@@ -103,12 +103,13 @@ test_that("cff_dependency_rows normalizes versions and dependency scopes", {
 })
 
 test_that("cff_dependency_year extracts years from supported dates", {
-  mod <- list(`date-released` = "1995-02-01")
+  mod <- list(`date-released` = "1995-02-01", year = "1990")
   expect_identical(cff_dependency_year(mod), "1995")
 
   mod2 <- list(`date-released` = "1904/12/30")
   expect_identical(cff_dependency_year(mod2), "1904")
 
+  expect_identical(cff_dependency_year(list(year = "1999")), "1999")
   expect_null(cff_dependency_year(list()))
 })
 
@@ -156,6 +157,23 @@ test_that("dependency citations preserve source metadata", {
   expect_identical(dependency$title, "Original dependency title")
   expect_null(dependency$abstract)
   expect_identical(r_dependency$year, "1999")
+})
+
+test_that("dependency references preserve citation years", {
+  local_mocked_bindings(
+    cff_dependency_citation = function(package) {
+      list(title = "Dependency title", year = "1999")
+    },
+    cff_dependency_desc_fields = function(mod, package) mod
+  )
+
+  result <- cff_dependency_reference(list(
+    package = "example",
+    version_clean = "1.0",
+    scope = "Imports"
+  ))
+
+  expect_identical(result$year, "1999")
 })
 
 test_that("cff_dependency_order uses canonical field order", {

--- a/tests/testthat/test-utils-create.R
+++ b/tests/testthat/test-utils-create.R
@@ -45,24 +45,34 @@ test_that("citation merging retains one copy of each identifier", {
   expect_identical(identifier_values, c(cran_doi, other_doi))
 })
 
-test_that("dependency helpers select supported package dependencies", {
+test_that("get_dependencies preserves package citation metadata", {
   skip_on_cran()
-  deps <- get_dependencies(system.file("DESCRIPTION", package = "cffr"))
+  desc_path <- system.file("DESCRIPTION", package = "cffr")
+  dep_rows <- desc::desc(desc_path)$get_deps()
+  dep_rows <- cff_dependency_rows(dep_rows)
+  installed <- as.character(installed.packages()[, "Package"])
+  dep_rows <- dep_rows[dep_rows$package %in% c("R", installed), ]
 
-  # Extract selected fields
-  selected <- lapply(deps, function(x) {
-    y <- x[names(x) %in% c("title", "url", "repository")]
-    y
+  actual <- get_dependencies(desc_path)
+  actual <- lapply(actual, \(x) drop_null(x[c("title", "abstract", "year")]))
+
+  expected <- lapply(dep_rows$package, function(package) {
+    raw_citation <- if (package == "R") {
+      utils::citation()
+    } else {
+      utils::citation(package, auto = TRUE)[1]
+    }
+    citation_cff <- as_cff(raw_citation)[[1]]
+
+    date_released <- citation_cff[["date-released"]]
+    if (!is.null(date_released)) {
+      citation_cff$year <- format(as.Date(date_released), "%Y")
+    }
+
+    drop_null(citation_cff[c("title", "abstract", "year")])
   })
 
-  # Select just a sample of dependencies
-  selected <- selected[seq(1, 3)]
-
-  class(selected) <- "cff"
-
-  rvers <- getRversion()
-  skip_if(!grepl("^4.6", rvers), "Snapshot created with R 4.6.*")
-  expect_snapshot(print(selected))
+  expect_setequal(unique(actual), unique(expected))
 })
 
 test_that("merge_cff resolves conflicting DESCRIPTION and CITATION URLs", {
@@ -160,6 +170,9 @@ test_that("dependency citations preserve source metadata", {
 })
 
 test_that("dependency references preserve citation years", {
+  rvers <- getRversion()
+  skip_if(!grepl("^4.6", rvers), "Snapshot created with R 4.6.*")
+
   local_mocked_bindings(
     cff_dependency_citation = function(package) {
       list(title = "Dependency title", year = "1999")
@@ -173,7 +186,7 @@ test_that("dependency references preserve citation years", {
     scope = "Imports"
   ))
 
-  expect_identical(result$year, "1999")
+  expect_snapshot(result)
 })
 
 test_that("cff_dependency_order uses canonical field order", {

--- a/tests/testthat/test-utils-create.R
+++ b/tests/testthat/test-utils-create.R
@@ -108,14 +108,54 @@ test_that("cff_dependency_year extracts years from supported dates", {
 
   mod2 <- list(`date-released` = "1904/12/30")
   expect_identical(cff_dependency_year(mod2), "1904")
+
+  expect_null(cff_dependency_year(list()))
 })
 
-test_that("is_cran_dependency excludes base and unavailable packages", {
-  avail <- data.frame(Package = c("foo", "stats"))
-  withr::local_options(cffr.available_packages = avail)
-  expect_true(is_cran_dependency("foo"))
-  expect_false(is_cran_dependency("stats"))
-  expect_false(is_cran_dependency("bar"))
+test_that("is_cran_dependency checks the package repository", {
+  avail <- data.frame(
+    Package = c("foo", "bar", "stats"),
+    Repository = c(
+      "https://cloud.r-project.org/src/contrib",
+      "https://fixture.r-universe.dev/src/contrib",
+      "https://cloud.r-project.org/src/contrib"
+    )
+  )
+  withr::local_options(
+    cffr.available_packages = avail,
+    cffr.repos = c(
+      fixture = "https://fixture.r-universe.dev",
+      CRAN = "https://cloud.r-project.org/"
+    )
+  )
+
+  result <- vapply(
+    c("foo", "bar", "stats", "unknown"),
+    is_cran_dependency,
+    logical(1)
+  )
+  expect_identical(unname(result), c(TRUE, FALSE, FALSE, FALSE))
+})
+
+test_that("dependency citations preserve source metadata", {
+  local_mocked_bindings(
+    cff_citation = function(...) {
+      bibentry(
+        bibtype = "Manual",
+        title = "Original dependency title",
+        author = person("Jane", "Doe"),
+        year = "1999"
+      )
+    },
+    is_cran_dependency = function(package) FALSE
+  )
+
+  dependency <- cff_dependency_citation("example")
+  r_dependency <- cff_dependency_citation("R")
+
+  expect_identical(dependency$title, "Original dependency title")
+  expect_null(dependency$abstract)
+  expect_identical(r_dependency$year, "1999")
 })
 
 test_that("cff_dependency_order uses canonical field order", {

--- a/vignettes/cffr.qmd
+++ b/vignettes/cffr.qmd
@@ -79,7 +79,9 @@ Under the hood, `cff_write()` performs these tasks:
 - Writes a `CITATION.cff` file.
 - Validates the result using `cff_validate()`.
 
-You now have a complete `CITATION.cff` file for your **R** package.
+You now have a `CITATION.cff` file populated from the available package
+metadata. The validation step reports any values that do not satisfy the CFF
+schema so that they can be corrected in their original metadata source.
 
 ## Modifying your `CITATION.cff` file
 

--- a/vignettes/r-cff.qmd
+++ b/vignettes/r-cff.qmd
@@ -432,7 +432,8 @@ calling `citation(auto = TRUE)` for each one. It preserves the title and
 abstract returned by `citation()`, adds URLs and repository information from the
 dependency's `DESCRIPTION` file and adds the canonical **CRAN** DOI only when the
 dependency is available from **CRAN**. The year is derived from the dependency's
-release date and is omitted when that date is unavailable.
+release date when available. Otherwise, **cffr** preserves the year returned by
+`citation()` and omits the year only when neither source provides one.
 
 ```{r}
 #| label: references

--- a/vignettes/r-cff.qmd
+++ b/vignettes/r-cff.qmd
@@ -407,8 +407,8 @@ all fields from `DESCRIPTION`, including custom fields, are available through
 the `meta` object used by the `CITATION` file. If multiple references are
 provided, **cffr** selects the first citation as `"preferred-citation"` and uses
 the remaining citations as [references](#references). If the file cannot be
-read with the package metadata, **cffr** reports the failure instead of retrying
-with metadata from another package.
+read with the package metadata, **cffr** does not retry with metadata from
+another package.
 
 ```{r}
 #| label: preferred-citation
@@ -428,12 +428,14 @@ The first citation becomes the [preferred citation](#preferred-citation) and the
 remaining citations become `"references"`.
 
 When `dependencies = TRUE`, **cffr** also adds installed package dependencies by
-calling `citation(auto = TRUE)` for each one. It preserves the title and
-abstract returned by `citation()`, adds URLs and repository information from the
-dependency's `DESCRIPTION` file and adds the canonical **CRAN** DOI only when the
-dependency is available from **CRAN**. The year is derived from the dependency's
-release date when available. Otherwise, **cffr** preserves the year returned by
-`citation()` and omits the year only when neither source provides one.
+calling `citation(auto = TRUE)` for each one. It preserves the citation metadata,
+including the title, abstract, authors and year, while adapting the reference to
+the CFF software type. It adds the dependency scope and version constraint from
+the source `DESCRIPTION`, URLs and repository information from the installed
+dependency's `DESCRIPTION` and the canonical **CRAN** DOI only when the
+dependency is available from **CRAN**. A release date, when available, determines
+the year; otherwise the year returned by `citation()` is retained. The year is
+omitted only when neither source provides one.
 
 ```{r}
 #| label: references

--- a/vignettes/r-cff.qmd
+++ b/vignettes/r-cff.qmd
@@ -45,7 +45,7 @@ keys <- cff_schema_keys(sorted = TRUE)
 origin <- vector(length = length(keys))
 origin[keys == "cff-version"] <- "function argument"
 origin[keys == "type"] <- "Fixed value: 'software'"
-origin[keys == "identifiers"] <- "DESCRIPTION and inst/CITATION"
+origin[keys == "identifiers"] <- "DESCRIPTION, inst/CITATION and CRAN"
 origin[keys == "references"] <- "DESCRIPTION and inst/CITATION"
 
 origin[
@@ -67,13 +67,8 @@ origin[
     )
 ] <- "DESCRIPTION file"
 
-origin[
-  keys %in%
-    c(
-      "doi",
-      "preferred-citation"
-    )
-] <- "inst/CITATION"
+origin[keys == "doi"] <- "inst/CITATION or CRAN"
+origin[keys == "preferred-citation"] <- "inst/CITATION"
 
 origin[origin == "FALSE"] <- "Ignored by cffr"
 
@@ -236,9 +231,12 @@ Back to @tbl-summary.
 ### doi {#doi}
 
 This key is coerced from the `"doi"` field of the
-[preferred-citation](#preferred-citation) object. If not present and the package
-is on **CRAN**, it is populated with the DOI provided by **CRAN** (for example,
-<https://doi.org/10.32614/CRAN.package.cffr>).
+[preferred-citation](#preferred-citation) object. If it is not present, **cffr**
+adds the canonical **CRAN** DOI only when the package metadata identifies
+**CRAN** as its repository or a repository lookup resolves to the canonical
+**CRAN** package URL. Finding the package in another configured repository does
+not produce a **CRAN** DOI. For example, the canonical DOI for **cffr** is
+<https://doi.org/10.32614/CRAN.package.cffr>.
 
 ```{r}
 #| label: doi
@@ -262,6 +260,9 @@ This key contains the available package identifiers:
   [preferred-citation](#preferred-citation).
 - If the package is on **CRAN** and it has a `CITATION` file providing a DOI,
   the DOI provided by **CRAN** is added as well.
+
+**cffr** removes identical entries after merging identifiers from these
+sources.
 
 ```{r}
 #| label: identifiers
@@ -401,9 +402,13 @@ Back to @tbl-summary.
 
 ### preferred-citation {#preferred-citation}
 
-This key is extracted from `inst/CITATION`. If multiple references are provided,
-it selects the first citation as `"preferred-citation"` and uses the remaining
-citations as [references](#references).
+This key is extracted from `inst/CITATION`. When `cff_create()` reads this file,
+all fields from `DESCRIPTION`, including custom fields, are available through
+the `meta` object used by the `CITATION` file. If multiple references are
+provided, **cffr** selects the first citation as `"preferred-citation"` and uses
+the remaining citations as [references](#references). If the file cannot be
+read with the package metadata, **cffr** reports the failure instead of retrying
+with metadata from another package.
 
 ```{r}
 #| label: preferred-citation
@@ -420,9 +425,14 @@ Back to @tbl-summary.
 
 This key is extracted from `inst/CITATION` if multiple references are provided.
 The first citation becomes the [preferred citation](#preferred-citation) and the
-remaining citations become `"references"`. **cffr** can also extract package
-dependencies and add them to this field by calling `citation(auto = TRUE)` for
-each dependency.
+remaining citations become `"references"`.
+
+When `dependencies = TRUE`, **cffr** also adds installed package dependencies by
+calling `citation(auto = TRUE)` for each one. It preserves the title and
+abstract returned by `citation()`, adds URLs and repository information from the
+dependency's `DESCRIPTION` file and adds the canonical **CRAN** DOI only when the
+dependency is available from **CRAN**. The year is derived from the dependency's
+release date and is omitted when that date is unavailable.
 
 ```{r}
 #| label: references


### PR DESCRIPTION
## Summary

- infer CRAN DOIs only for packages that are actually available from CRAN
- preserve dependency titles and abstracts and avoid synthesizing missing years
- expose all DESCRIPTION fields to CITATION files and stop retrying failed reads with metadata from the base package
- document the updated extraction behavior in the package vignettes
- add regression tests and update snapshots

## Testing

- devtools::test() (833 passed, 0 failed, 0 warnings, 0 skipped)
- devtools::build_vignettes() (all vignettes built successfully)
- devtools::lint() (no lints)
- jarl check . (all checks passed)